### PR TITLE
Phase 2.2 openhands execution

### DIFF
--- a/.codex.json
+++ b/.codex.json
@@ -247,5 +247,6 @@
   "codex/phase-4-agent-delegation": true,
   "codex/phase-4-agent-feedback-loop": true,
   "phase/2.1-dynamic-routing-metabase": true,
+  "phase/2.2-openhands-execution": true,
   "phase-1.4-observability-logging": true
 }

--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ LOG_JSON=false
 CORS_ALLOW_ORIGINS=*
 PROMETHEUS_MULTIPROC_DIR=/tmp
 
+# OpenHands Integration
+ENABLE_OPENHANDS=false
+OPENHANDS_API_URL=http://localhost:8102
+OPENHANDS_JWT=changeme
+
 # Storage Configuration
 DATA_DIR=./data
 SESSIONS_DIR=./data/sessions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,9 @@ Sessions und Vektordaten bei Neustarts erhalten bleiben.
 - Routing-Agent mit `rules.yaml` aktiviert
 - Dispatcher nutzt Routing-Agent für generische Tasks
 - Optionaler MetaLearner vorbereitet
+### Fortschritt Phase 2.2
+- OpenHands-Worker greift produktiv auf API zu
+- Tasks mit `task_type` `docker` oder `container_ops` werden an `worker_openhands` geroutet
 ## Allgemeine Projekt-Richtlinien
 
 Unabhängig von der Rolle gelten folgende übergreifende Regeln für den Codex-Agenten, um qualitativ hochwertige Beiträge zu gewährleisten:

--- a/agentnn_devplan_todo.md
+++ b/agentnn_devplan_todo.md
@@ -36,6 +36,7 @@
 - [ ] Provider-System erweitern.
 - [ ] Dynamische Konfiguration über `llm_config.yaml`.
 - [ ] SDK-Beispiele und Tests hinzufügen.
+- [x] OpenHands API Anbindung produktiv aktivieren.
 
 ### 2.3 System-Harmonisierung & Legacy-Migration
 - [ ] Bestehende Funktionen angleichen.

--- a/mcp/agents.yaml
+++ b/mcp/agents.yaml
@@ -5,3 +5,6 @@ agents:
     url: http://worker_loh:8000
   - name: worker_openhands
     url: http://worker_openhands:8000
+    capabilities:
+      - docker
+      - container_ops

--- a/services/routing_agent/rules.yaml
+++ b/services/routing_agent/rules.yaml
@@ -1,2 +1,4 @@
 greeting: worker_dev
 search: wikipedia
+docker: worker_openhands
+container_ops: worker_openhands

--- a/tests/mocks/fake_openhands.py
+++ b/tests/mocks/fake_openhands.py
@@ -1,0 +1,35 @@
+import asyncio
+from aiohttp import web
+
+class FakeOpenHandsServer:
+    """Minimal async server mocking OpenHands API."""
+
+    def __init__(self):
+        self.app = web.Application()
+        self.app.router.add_post('/docker/run', self.run_container)
+        self.runner = web.AppRunner(self.app)
+        self.site = None
+        self.port = None
+
+    async def run_container(self, request: web.Request) -> web.Response:
+        data = await request.json()
+        fail = data.get('fail')
+        if fail == 'unauthorized':
+            return web.Response(status=401)
+        if fail == 'error':
+            return web.Response(status=500)
+        return web.json_response({'container_id': 'mock123', 'status': 'running', 'logs': 'started'})
+
+    async def __aenter__(self):
+        await self.runner.setup()
+        self.site = web.TCPSite(self.runner, 'localhost', 0)
+        await self.site.start()
+        self.port = self.site._server.sockets[0].getsockname()[1]
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.runner.cleanup()
+
+    @property
+    def url(self) -> str:
+        return f'http://localhost:{self.port}'

--- a/tests/test_worker_openhands.py
+++ b/tests/test_worker_openhands.py
@@ -1,0 +1,123 @@
+import os
+import json
+import asyncio
+import sys
+import types
+
+import pytest
+
+module_mlflow = types.ModuleType('mlflow')
+setattr(module_mlflow, 'active_run', lambda: None)
+setattr(module_mlflow, 'start_run', lambda *a, **kw: None)
+setattr(module_mlflow, 'end_run', lambda: None)
+sys.modules.setdefault('mlflow', module_mlflow)
+sys.modules.setdefault('torch', types.ModuleType('torch'))
+setattr(sys.modules['torch'], 'Tensor', object)
+sys.modules.setdefault('langchain', types.ModuleType('langchain'))
+module_schema = types.ModuleType('langchain.schema')
+setattr(module_schema, 'Document', object)
+sys.modules.setdefault('langchain.schema', module_schema)
+module_chains = types.ModuleType('langchain.chains')
+setattr(module_chains, 'RetrievalQA', object)
+sys.modules.setdefault('langchain.chains', module_chains)
+module_prompts = types.ModuleType('langchain.prompts')
+setattr(module_prompts, 'PromptTemplate', object)
+sys.modules.setdefault('langchain.prompts', module_prompts)
+sys.modules.setdefault('langchain_core', types.ModuleType('langchain_core'))
+module_core_runnables = types.ModuleType('langchain_core.runnables')
+setattr(module_core_runnables, 'RunnablePassthrough', object)
+sys.modules.setdefault('langchain_core.runnables', module_core_runnables)
+module_core_llms = types.ModuleType('langchain_core.language_models.llms')
+setattr(module_core_llms, 'BaseLLM', object)
+sys.modules.setdefault('langchain_core.language_models.llms', module_core_llms)
+module_core_callbacks = types.ModuleType('langchain_core.callbacks.manager')
+setattr(module_core_callbacks, 'CallbackManagerForLLMRun', object)
+sys.modules.setdefault('langchain_core.callbacks.manager', module_core_callbacks)
+sys.modules.setdefault('langchain_openai', types.ModuleType('langchain_openai'))
+module_openai = sys.modules['langchain_openai']
+setattr(module_openai, 'OpenAI', object)
+setattr(module_openai, 'ChatOpenAI', object)
+setattr(module_openai, 'OpenAIEmbeddings', object)
+sys.modules.setdefault('datastores.worker_agent_db', types.ModuleType('datastore_db'))
+class _DB:
+    def __init__(self, name: str):
+        self.name = name
+sys.modules['datastores.worker_agent_db'].WorkerAgentDB = _DB
+sys.modules.setdefault('llm_models.specialized_llm', types.ModuleType('special_llm'))
+class _Special:
+    def __init__(self, *a, **kw):
+        pass
+sys.modules['llm_models.specialized_llm'].SpecializedLLM = _Special
+sys.modules.setdefault('nn_models.agent_nn', types.ModuleType('agent_nn'))
+setattr(sys.modules['nn_models.agent_nn'], 'AgentNN', object)
+setattr(sys.modules['nn_models.agent_nn'], 'TaskMetrics', object)
+sys.modules.setdefault('agents.agent_communication', types.ModuleType('agent_communication'))
+setattr(sys.modules['agents.agent_communication'], 'AgentCommunicationHub', object)
+setattr(sys.modules['agents.agent_communication'], 'AgentMessage', object)
+class _MT:
+    RESPONSE = 'response'
+setattr(sys.modules['agents.agent_communication'], 'MessageType', _MT)
+sys.modules.setdefault('agents.domain_knowledge', types.ModuleType('domain_knowledge'))
+setattr(sys.modules['agents.domain_knowledge'], 'DomainKnowledgeManager', object)
+
+from mcp.worker_openhands.service import WorkerService
+from tests.mocks.fake_openhands import FakeOpenHandsServer
+
+
+class DummyDocker:
+    def __init__(self, *a, **kw):
+        pass
+
+    async def initialize(self):
+        pass
+
+    async def run_container(self, **kwargs):
+        return {"container_id": "mock123", "status": "running", "logs": ""}
+
+
+@pytest.mark.asyncio
+async def test_worker_openhands_success(monkeypatch):
+    async with FakeOpenHandsServer() as server:
+        monkeypatch.setenv('ENABLE_OPENHANDS', 'true')
+        monkeypatch.setenv('OPENHANDS_API_URL', server.url)
+        monkeypatch.setenv('OPENHANDS_JWT', 'dummy')
+        monkeypatch.setattr('mcp.worker_openhands.service.DockerAgent', DummyDocker)
+        service = WorkerService()
+        payload = json.dumps({'operation': 'start_container', 'image': 'alpine'})
+        result = service.execute_task(payload)
+        assert result['status'] == 'running'
+        assert result['operation_id'] == 'mock123'
+
+
+@pytest.mark.asyncio
+async def test_worker_openhands_unauthorized(monkeypatch):
+    async with FakeOpenHandsServer() as server:
+        monkeypatch.setenv('ENABLE_OPENHANDS', 'true')
+        monkeypatch.setenv('OPENHANDS_API_URL', server.url)
+        monkeypatch.setenv('OPENHANDS_JWT', 'dummy')
+        monkeypatch.setattr('mcp.worker_openhands.service.DockerAgent', DummyDocker)
+        service = WorkerService()
+        payload = json.dumps({'operation': 'start_container', 'fail': 'unauthorized'})
+        result = service.execute_task(payload)
+        assert result['status'] == 'error'
+        assert '401' in result['error'] or 'Unauthorized' in result['error']
+
+
+@pytest.mark.asyncio
+async def test_worker_openhands_timeout(monkeypatch):
+    async with FakeOpenHandsServer() as server:
+        monkeypatch.setenv('ENABLE_OPENHANDS', 'true')
+        monkeypatch.setenv('OPENHANDS_API_URL', server.url)
+        monkeypatch.setenv('OPENHANDS_JWT', 'dummy')
+        monkeypatch.setattr('mcp.worker_openhands.service.DockerAgent', DummyDocker)
+        service = WorkerService()
+
+        # monkeypatch run_container to sleep causing timeout
+        async def slow_run(*args, **kwargs):
+            await asyncio.sleep(31)
+        monkeypatch.setattr(service.agent, 'run_container', slow_run)
+
+        payload = json.dumps({'operation': 'start_container', 'image': 'alpine'})
+        result = service.execute_task(payload)
+        assert result['status'] == 'error'
+        assert result['error'] == 'timeout'


### PR DESCRIPTION
## Summary
- enable OpenHands worker via API instead of LLM
- route docker/container tasks to worker_openhands
- extend agentnn CLI with `--task-type`
- document phase 2.2 progress and update config
- provide fake OpenHands server and worker tests

## Testing
- `ruff check .`
- `mypy mcp` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pytest -k worker_openhands -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_6858ef036c4483248db3b7fdd9d02e49