### PR TITLE
phase/1.final-core-consistency

### DIFF
--- a/.codex.json
+++ b/.codex.json
@@ -248,5 +248,6 @@
   "codex/phase-4-agent-feedback-loop": true,
   "phase/2.1-dynamic-routing-metabase": true,
   "phase/2.2-openhands-execution": true,
-  "phase-1.4-observability-logging": true
+  "phase-1.4-observability-logging": true,
+  "phase/1.final-core-consistency": true
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,21 +93,21 @@ Sessions und Vektordaten bei Neustarts erhalten bleiben.
 - Docker-Compose Setup erstellt und einfacher End-to-End-Test erfolgreich
 
 ### Fortschritt Phase 1.2
-- MCP-SDK als Zugriffsschicht eingebunden
-- Dispatcher ruft Registry, Session-Manager und LLM-Gateway über HTTP
-- Erste REST-Routen wie `/dispatch`, `/chat` und `/agents` umgesetzt
-- Vector-Store um `embed`, `search` und `add_document` erweitert
-- Aktualisierter End-to-End-Test erfolgreich
+- ✓ MCP-SDK als Zugriffsschicht eingebunden
+- ✓ Dispatcher ruft Registry, Session-Manager und LLM-Gateway über HTTP
+- ✓ Erste REST-Routen wie `/dispatch`, `/chat` und `/agents` umgesetzt
+- ✓ Vector-Store um `embed`, `search` und `add_document` erweitert
+- ✓ Aktualisierter End-to-End-Test erfolgreich
 
 ### Fortschritt Phase 1.3
-- API-Gateway konsolidiert alle externen Endpunkte
-- Authentifizierung über API-Key oder JWT optional
-- Interne Service-Requests nutzen Retry-Mechanismen
-- Fehlende Abhängigkeiten in Build-Skripten ergänzt
+- ✓ API-Gateway konsolidiert alle externen Endpunkte
+- ✓ Authentifizierung über API-Key oder JWT optional
+- ✓ Interne Service-Requests nutzen Retry-Mechanismen
+- ✓ Fehlende Abhängigkeiten in Build-Skripten ergänzt
 
 ### Fortschritt Phase 1.4
-- Einheitliches Logging über alle Services mit JSON-Option
-- Prometheus-Metriken pro Service unter `/metrics`
+- ✓ Einheitliches Logging über alle Services mit JSON-Option
+- ✓ Prometheus-Metriken pro Service unter `/metrics`
 - Docker-Compose beinhaltet nun einen Prometheus-Container
 ### Fortschritt Phase 2.1
 - Routing-Agent mit `rules.yaml` aktiviert

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ graph TD
 2. Abhängigkeiten installieren
    ```bash
    pip install -r requirements.txt
+   cp .env.example .env  # lokale Konfiguration
    ```
 3. Basis-Services starten
    ```bash
-   docker-compose up dispatcher registry session-manager
+   docker-compose up dispatcher registry session-manager vector_store llm_gateway
    ```
 4. Testanfrage stellen
 ```bash
@@ -58,6 +59,13 @@ Das Kommando `agentnn` wird nach der Installation verfügbar. Die Version kann m
 agentnn --version
 ```
 abgerufen werden.
+
+Wichtige Befehle:
+```bash
+agentnn agents     # verfügbare Agents auflisten
+agentnn sessions   # aktive Sessions anzeigen
+agentnn feedback   # Feedback-Tools
+```
 
 Weitere Details findest du im Ordner [docs/](docs/).
 

--- a/agentnn_devplan_todo.md
+++ b/agentnn_devplan_todo.md
@@ -10,19 +10,19 @@
 - [x] Ersten End-to-End-Test durchführen: Dummy-Request über alle Services schleusen.
 
 ### 1.2 Kernservices & Kontext-Integration
-- [ ] MCP-SDK integrieren & Basis-Routing implementieren.
-- [ ] LLM-Gateway-Anbindung umsetzen.
-- [ ] VectorStore-Service integrieren.
-- [ ] Session-Manager mit persistentem Kontext.
+- [x] MCP-SDK integrieren & Basis-Routing implementieren.
+- [x] LLM-Gateway-Anbindung umsetzen.
+- [x] VectorStore-Service integrieren.
+- [x] Session-Manager mit persistentem Kontext.
 
 ### 1.3 Infrastruktur & Sicherheit
-- [ ] Monitoring- und Logging-Infrastruktur einführen.
-- [ ] Sicherheits-Layer implementieren.
-- [ ] Persistente Speicherpfade & Konfiguration festlegen.
+- [x] Monitoring- und Logging-Infrastruktur einführen.
+- [x] Sicherheits-Layer implementieren.
+- [x] Persistente Speicherpfade & Konfiguration festlegen.
 
 ### 1.4 Entwickler-Tools & Release-Vorbereitung
-- [ ] Developer-SDK und CLI bereitstellen.
-- [ ] Erste Beta-Release vorbereiten.
+- [x] Developer-SDK und CLI bereitstellen.
+- [x] Erste Beta-Release vorbereiten.
 
 ## Phase 2: Feature-Integration & Harmonisierung
 

--- a/codex-init.sh
+++ b/codex-init.sh
@@ -9,7 +9,7 @@ curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2
 sudo npm install -g pnpm
 # Python dev tools
 python3.11 -m pip install --upgrade pip
-python3.11 -m pip install poetry ruff black pytest httpx fastapi uvicorn mypy bandit tox coverage pydantic slowapi prometheus-client aiofiles loguru python-json-logger aiohttp structlog
+python3.11 -m pip install poetry ruff black pytest httpx fastapi uvicorn mypy bandit tox coverage pydantic slowapi prometheus-client aiofiles loguru python-json-logger aiohttp structlog cryptography
 # Frontend testing tools
 sudo npm install -g playwright jest
 # Optional diagram tool

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,24 @@
+# Architecture Overview
+
+This document provides a short overview of the services composing the Agent-NN Modular Control Plane.
+
+```mermaid
+graph TD
+    API[API Gateway] --> DISP[Task Dispatcher]
+    DISP --> REG[Agent Registry]
+    DISP --> SESS[Session Manager]
+    DISP --> WORK[Worker Services]
+    DISP --> VEC[Vector Store]
+    DISP --> LLM[LLM Gateway]
+    WORK --> VEC
+    WORK --> LLM
+```
+
+* **Task Dispatcher** – entrypoint for tasks and routing logic.
+* **Agent Registry** – stores metadata about available worker agents.
+* **Session Manager** – persists conversation contexts and feedback.
+* **Vector Store** – manages document embeddings and similarity search.
+* **LLM Gateway** – unified API for text generation and embeddings.
+* **Worker Services** – domain-specific agents executing subtasks.
+
+All services expose `/health` and `/metrics` endpoints and can be configured via environment variables found in `.env.example`.

--- a/sdk/client/agent_client.py
+++ b/sdk/client/agent_client.py
@@ -50,10 +50,19 @@ class AgentClient:
         resp.raise_for_status()
         return resp.json()
 
+    # backwards compatibility helpers
+    def get_agents(self) -> Dict[str, Any]:
+        """Alias for :meth:`list_agents`."""
+        return self.list_agents()
+
     def list_sessions(self) -> Dict[str, Any]:
         resp = self._client.get("/sessions", headers=self._headers())
         resp.raise_for_status()
         return resp.json()
+
+    def get_sessions(self) -> Dict[str, Any]:
+        """Alias for :meth:`list_sessions`."""
+        return self.list_sessions()
 
     def get_session_history(self, session_id: str) -> Dict[str, Any]:
         resp = self._client.get(f"/context/{session_id}", headers=self._headers())
@@ -64,6 +73,14 @@ class AgentClient:
         payload = {"query": query, "collection": collection}
         resp = self._client.post(
             "/vector_search", json=payload, headers=self._headers()
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_embeddings(self, text: str) -> Dict[str, Any]:
+        """Return embeddings using the vector store."""
+        resp = self._client.post(
+            "/embed", json={"text": text}, headers=self._headers()
         )
         resp.raise_for_status()
         return resp.json()

--- a/services/session_manager/service.py
+++ b/services/session_manager/service.py
@@ -57,6 +57,8 @@ class SessionManagerService:
             "input": ctx.task_context.description if ctx.task_context else None,
             "output": ctx.result,
             "score": ctx.agents[-1].score if ctx.agents else None,
+            "user_id": ctx.user_id,
+            "feedback": ctx.agents[-1].feedback if ctx.agents else None,
             "timestamp": ctx.timestamp.isoformat(),
         }
         self.memory.append_memory(ctx.session_id, entry)

--- a/services/vector_store/service.py
+++ b/services/vector_store/service.py
@@ -23,7 +23,7 @@ class VectorStoreService:
         backend = settings.VECTOR_DB_BACKEND.lower()
         if backend == "chromadb":
             self.client = chromadb.PersistentClient(path=settings.VECTOR_DB_DIR)
-            self.collections = {}
+            self.collections: Dict[str, Any] = {}
         else:
             self.client = None
             self.collections: Dict[str, Dict[str, List]] = defaultdict(

--- a/tests/llm_gateway/test_llm_routes.py
+++ b/tests/llm_gateway/test_llm_routes.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+from services.llm_gateway.routes import router, service
+from fastapi import FastAPI
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+def test_generate_route(monkeypatch):
+    monkeypatch.setattr(service, "generate", lambda prompt, model_name=None, temperature=0.7: {"completion": "hi", "tokens_used": 1, "provider": "dummy"})
+    resp = client.post("/generate", json={"prompt": "hi"})
+    assert resp.status_code == 200
+    assert resp.json()["completion"] == "hi"
+
+
+def test_embed_route(monkeypatch):
+    monkeypatch.setattr(service, "embed", lambda text, model_name=None: {"embedding": [1.0], "provider": "dummy"})
+    resp = client.post("/embed", json={"text": "hi"})
+    assert resp.status_code == 200
+    assert resp.json()["embedding"] == [1.0]

--- a/tests/sdk/test_agent_client.py
+++ b/tests/sdk/test_agent_client.py
@@ -42,3 +42,19 @@ def test_list_agents(monkeypatch):
     client = AgentClient()
     client.list_agents()
     assert dummy.sent[0][0].endswith("/agents")
+
+
+def test_new_helpers(monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr("httpx.Client", lambda base_url: dummy)
+    client = AgentClient()
+    client.get_agents()
+    client.get_sessions()
+    client.get_embeddings("hi")
+    ctx = type("C", (), {"model_dump": lambda self: {"a": 1}})()
+    client.dispatch_task(ctx)
+    paths = [call[0] for call in dummy.sent]
+    assert "/agents" in paths[0]
+    assert "/sessions" in paths[1]
+    assert "/embed" in paths[2]
+    assert "/dispatch" in paths[3]

--- a/tests/vector_store/test_routes.py
+++ b/tests/vector_store/test_routes.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+from services.vector_store.routes import router, service
+from fastapi import FastAPI
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+def test_search_route(monkeypatch):
+    monkeypatch.setattr(service, "search", lambda q, c, top_k=3: {"matches": [{"id": "1"}], "model": "dummy"})
+    resp = client.post("/vector_search", json={"query": "hi", "collection": "c", "top_k": 1})
+    assert resp.status_code == 200
+    assert resp.json()["matches"][0]["id"] == "1"
+
+
+def test_embed_route(monkeypatch):
+    monkeypatch.setattr(service, "embed", lambda text: {"embedding": [1.0], "model": "dummy"})
+    resp = client.post("/embed", json={"text": "hi"})
+    assert resp.status_code == 200
+    assert resp.json()["embedding"] == [1.0]


### PR DESCRIPTION
## Summary
- mark phase 1 progress in `AGENTS.md`
- document tasks as done in `agentnn_devplan_todo.md`
- install cryptography in `codex-init.sh`
- extend SDK client with helper methods and embedding call
- store user and feedback info in session manager
- fix type hints in vector store service
- document architecture overview
- expand install steps and CLI usage in README
- update project manifest to flag phase completion
- add API route tests for LLM gateway and vector store
- adjust SDK client tests

## Testing
- `ruff check .`
- `mypy sdk/client/agent_client.py --ignore-missing-imports --follow-imports=skip`
- `pytest tests/sdk/test_agent_client.py tests/llm_gateway/test_llm_routes.py tests/vector_store/test_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6858f2fc10a483249ee5582d4ea15f9d