### PR TITLE
Add integration plan and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ Unabhängig von der Rolle gelten folgende übergreifende Regeln für den Codex-A
 - **Atomare Commits:** Aufgaben möglichst in kleinen, nachvollziehbaren Commits abschließen. Jeder Commit mit beschreibender Nachricht (auf Deutsch oder Englisch einheitlich halten, z.B. Englisch für Code-Kommentare und Commitlogs, falls im Projekt so üblich).  
 - **Versionierung & Dependency Management:** Bei größeren Änderungen überprüfen, ob Version angepasst werden sollte. Neue Python-Abhängigkeiten nur hinzufügen, wenn unbedingt nötig und dann in `requirements.txt` bzw. `pyproject.toml` vermerken.  
 - **Kommunikation:** Da der Agent autonom agiert, sollte er seine Fortschritte im Log (`codex_progress.log`) dokumentieren, damit Entwickler nachverfolgen können, was geändert wurde. Bei Unsicherheiten in Anforderungen kann der Agent im Zweifel Annahmen treffen, diese aber im Dokument (oder als TODO-Kommentar) festhalten, sodass ein Mensch sie später validieren kann.
-- **Integrationen:** Neue Plugins für n8n und FlowiseAI befinden sich unter `plugins/`. Dokumentation siehe `docs/integrations/`. Bei Erweiterungen stets auf API-Kompatibilität achten.
+- **Integrationen:** Neue Plugins für n8n und FlowiseAI befinden sich unter `plugins/`. Ausführliche Hinweise und ein Integrationsplan sind in `docs/integrations/` dokumentiert. Bei Erweiterungen stets auf API-Kompatibilität achten.
 
 *Ende der AGENTS.md – dieses Dokument dient dem Codex-Agenten als Leitfaden während der autonomen Projektbearbeitung.*
 

--- a/docs/integrations/flowise.md
+++ b/docs/integrations/flowise.md
@@ -1,16 +1,45 @@
 # FlowiseAI Integration
 
-[FlowiseAI](https://flowiseai.com/) ermöglicht das visuelle Erstellen von LLM-Flows.
-Mit dem Plugin `flowise_workflow` lassen sich Chatflows per HTTP aus Agent-NN heraus
-aufrufen.
+[FlowiseAI](https://flowiseai.com/) bietet eine grafische Oberfläche zum Erstellen von Chatbot‑Flows. Agent‑NN lässt sich sowohl als Quelle für Antworten als auch als externer Aufrufer nutzen.
 
-## Beispiel
+## Agent‑NN als Flowise Komponente
+
+Eine Custom Component kann Anfragen an den Dispatcher schicken und die Antwort im Flow weiterverwenden. Das folgende TypeScript‑Fragment zeigt den Kern:
+
+```ts
+import axios from 'axios';
+
+export default class AgentNN {
+  constructor(private endpoint: string) {}
+
+  async run(question: string) {
+    const { data } = await axios.post(`${this.endpoint}/task`, {
+      task_type: 'chat',
+      input: question,
+    });
+    return data.result;
+  }
+}
+```
+
+Diese Komponente wird in Flowise eingebunden und erlaubt es, Benutzeranfragen direkt an Agent‑NN zu delegieren.
+
+## Flowise Workflows aus Agent‑NN anstoßen
+
+Das Plugin `flowise_workflow` ruft HTTP‑basierte Chatflows auf. Es akzeptiert optionale Header und einen Payload:
 
 ```python
 from plugins.flowise_workflow.plugin import Plugin
 
 plugin = Plugin()
-result = plugin.execute({"url": "http://localhost:3000/api/v1/predict", "payload": {"question": "Hi"}}, {})
+result = plugin.execute(
+    {
+        "url": "http://localhost:3000/api/v1/predict",
+        "payload": {"question": "Hi"},
+        "headers": {"Authorization": "Bearer token"},
+    },
+    {},
+)
 ```
 
-So kann ein Flowise-Chatbot direkt in Agent-NN Aufgaben bearbeiten.
+So kann ein Flowise‑Chatbot direkt in Agent‑NN Aufgaben bearbeiten oder Informationen abrufen.

--- a/docs/integrations/full_integration_plan.md
+++ b/docs/integrations/full_integration_plan.md
@@ -1,0 +1,46 @@
+# Plan zur vollständigen Integration von Agent-NN mit n8n und FlowiseAI
+
+Dieser Plan beschreibt die nötigen Schritte, um Agent‑NN in beide Richtungen mit n8n und FlowiseAI zu koppeln. Ziel ist es, Workflows zwischen den Systemen auszutauschen und Agent‑NN sowohl als Quelle als auch als Ziel von Automatisierungsflüssen zu verwenden.
+
+## 1. Überblick
+
+- **Agent‑NN in n8n nutzen:** Bereitstellung eines eigenen n8n Nodes, der Aufgaben an den Agent‑NN Dispatcher sendet und Antworten verarbeitet.
+- **Agent‑NN in FlowiseAI nutzen:** Entwicklung einer Flowise-Komponente, die Agent‑NN als externen Chat-Endpunkt anspricht.
+- **n8n und FlowiseAI aus Agent‑NN heraus aufrufen:** Erweiterung der bestehenden Plugins, um Authentifizierung und Fehlerbehandlung zu unterstützen.
+
+## 2. n8n Node für Agent‑NN
+
+1. Neues Paket unter `integrations/n8n-agentnn` mit TypeScript-Quellcode anlegen.
+2. Implementation eines `AgentNN` Nodes, der folgende Parameter besitzt:
+   - `endpoint`: Basis-URL des API-Gateways
+   - `task_type`: Art der Aufgabe (z. B. `chat`)
+   - `payload`: Freies JSON-Feld für Eingabedaten
+3. Der Node sendet eine POST-Anfrage an `/task` und gibt die JSON-Antwort zurück.
+4. Veröffentlichung als benutzerdefiniertes n8n-Paket (Installationsanleitung in der Doku).
+
+## 3. FlowiseAI Komponente
+
+1. Neues Modul `integrations/flowise-agentnn` mit einem Custom Component Script (`AgentNN.ts`).
+2. Das Script erlaubt die Konfiguration der Agent‑NN URL und weiterer Parameter.
+3. Eingehende Prompts werden an Agent‑NN weitergeleitet; die Antwort des Dispatchers wird als Chatbot-Antwort ausgegeben.
+4. Bereitstellung über das Flowise Plugin System.
+
+## 4. Verbesserte Plugins in Agent‑NN
+
+- Erweiterung der Plugins `n8n_workflow` und `flowise_workflow` um optionale Auth‑Header sowie konfigurierbare Timeouts.
+- Dokumentation aller Felder in den Plugin-Manifests.
+- Beispielskript `run_plugin_task.py` aktualisieren, um beide Plugins komfortabel testen zu können.
+
+## 5. Dokumentation
+
+- Ausführliche Installations‑ und Nutzungshinweise in `docs/integrations/n8n.md` und `docs/integrations/flowise.md` ergänzen.
+- Neue Seite `full_integration_plan.md` in `mkdocs.yml` verlinken.
+- Schritt-für-Schritt-Anleitung zur Einrichtung der Custom Nodes/Components.
+
+## 6. Tests und CI
+
+- Unit Tests für die Plugin-Erweiterungen schreiben (z. B. Fehlerfälle und Header-Weitergabe).
+- End-to-End-Test, der einen simplen n8n bzw. Flowise Mock aufruft.
+- Sicherstellen, dass `tests/ci_check.sh` alle neuen Module erfasst.
+
+Durch Umsetzung dieses Plans wird Agent‑NN sowohl von n8n als auch von FlowiseAI aus ansprechbar sein und umgekehrt externe Workflows nutzen können.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,4 +1,5 @@
 # Integrations
 
-Dieses Kapitel beschreibt, wie Agent-NN mit externen Tools gekoppelt werden kann.
-Derzeit werden neben der Smolitux-UI auch n8n und FlowiseAI unterstützt.
+Dieses Kapitel beschreibt, wie Agent-NN mit externen Tools gekoppelt werden kann. Neben der Smolitux-UI stehen Erweiterungen für n8n und FlowiseAI bereit.
+
+Eine ausführliche Roadmap zur beidseitigen Integration findet sich in [full_integration_plan.md](full_integration_plan.md).

--- a/docs/integrations/n8n.md
+++ b/docs/integrations/n8n.md
@@ -1,17 +1,52 @@
 # n8n Integration
 
-Die Workflow-Plattform [n8n](https://n8n.io/) kann Agent-NN über REST-Endpunkte ansprechen.
-Hierfür steht ein Plugin `n8n_workflow` bereit, das einen beliebigen Webhook oder
-REST-Workflow aufruft.
+Die Workflow-Plattform [n8n](https://n8n.io/) kann Agent‑NN sowohl aufrufen als auch von Agent‑NN aus gestartet werden.
 
-## Beispiel
+## Agent‑NN von n8n aus nutzen
+
+Für eine enge Anbindung empfiehlt sich ein eigener Node. Das folgende Beispiel zeigt ein minimales TypeScript-Snippet:
+
+```ts
+import { IExecuteFunctions } from 'n8n-core';
+import { IDataObject } from 'n8n-workflow';
+
+export async function execute(this: IExecuteFunctions): Promise<IDataObject[]> {
+  const endpoint = this.getNodeParameter('endpoint') as string;
+  const taskType = this.getNodeParameter('taskType') as string;
+  const payload = this.getNodeParameter('payload') as object;
+
+  const response = await this.helpers.request({
+    method: 'POST',
+    uri: `${endpoint}/task`,
+    body: {
+      task_type: taskType,
+      input: payload,
+    },
+    json: true,
+  });
+
+  return [response as IDataObject];
+}
+```
+
+Dieses Skript kann als Custom Node in n8n eingebunden werden und sendet Aufgaben direkt an das Agent‑NN API‑Gateway.
+
+## Agent‑NN ruft n8n Workflows auf
+
+Das Python‑Plugin `n8n_workflow` erlaubt es, beliebige Webhook‑ oder REST‑Workflows anzusprechen. Es unterstützt optionale Header und Payloads:
 
 ```python
 from plugins.n8n_workflow.plugin import Plugin
 
 plugin = Plugin()
-result = plugin.execute({"url": "http://localhost:5678/webhook/test", "payload": {"text": "Hallo"}}, {})
+result = plugin.execute(
+    {
+        "url": "http://localhost:5678/webhook/test",
+        "payload": {"text": "Hallo"},
+        "headers": {"X-Api-Key": "token"},
+    },
+    {},
+)
 ```
 
-Der Aufruf gibt die Antwort des Workflows zurück. In n8n muss dazu ein Webhook-
-Node oder eine HTTP Request URL bereitgestellt werden.
+Der Aufruf gibt die Antwort des Workflows zurück.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
     - Smolitux UI: smolitux-ui-integration.md
     - n8n: integrations/n8n.md
     - FlowiseAI: integrations/flowise.md
+    - Full Integration Plan: integrations/full_integration_plan.md
   - API Reference:
     - Agents: api/agents.md
     - Managers: api/managers.md


### PR DESCRIPTION
## Summary
- document full integration of Agent-NN with n8n and FlowiseAI
- expand n8n and Flowise usage examples
- link new plan from docs and AGENTS.md

## Testing
- `./tests/ci_check.sh` *(fails: pytest missing arguments and mypy missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865084de9608324aaed50a9ec856e09