### PR TITLE
Extend n8n & Flowise docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ Unabhängig von der Rolle gelten folgende übergreifende Regeln für den Codex-A
 - **Atomare Commits:** Aufgaben möglichst in kleinen, nachvollziehbaren Commits abschließen. Jeder Commit mit beschreibender Nachricht (auf Deutsch oder Englisch einheitlich halten, z.B. Englisch für Code-Kommentare und Commitlogs, falls im Projekt so üblich).  
 - **Versionierung & Dependency Management:** Bei größeren Änderungen überprüfen, ob Version angepasst werden sollte. Neue Python-Abhängigkeiten nur hinzufügen, wenn unbedingt nötig und dann in `requirements.txt` bzw. `pyproject.toml` vermerken.  
 - **Kommunikation:** Da der Agent autonom agiert, sollte er seine Fortschritte im Log (`codex_progress.log`) dokumentieren, damit Entwickler nachverfolgen können, was geändert wurde. Bei Unsicherheiten in Anforderungen kann der Agent im Zweifel Annahmen treffen, diese aber im Dokument (oder als TODO-Kommentar) festhalten, sodass ein Mensch sie später validieren kann.
-- **Integrationen:** Neue Plugins für n8n und FlowiseAI befinden sich unter `plugins/`. Ausführliche Hinweise und ein Integrationsplan sind in `docs/integrations/` dokumentiert. Bei Erweiterungen stets auf API-Kompatibilität achten.
+- **Integrationen:** Plugins für n8n und FlowiseAI liegen unter `plugins/`. Beispielimplementierungen der Custom Nodes/Components findest du in `integrations/`. Ausführliche Hinweise und ein Integrationsplan sind in `docs/integrations/` dokumentiert. Bei Erweiterungen stets auf API-Kompatibilität achten und die optionale Übergabe von `method` und `timeout` berücksichtigen.
 
 *Ende der AGENTS.md – dieses Dokument dient dem Codex-Agenten als Leitfaden während der autonomen Projektbearbeitung.*
 

--- a/docs/integrations/flowise.md
+++ b/docs/integrations/flowise.md
@@ -4,7 +4,7 @@
 
 ## Agent‑NN als Flowise Komponente
 
-Eine Custom Component kann Anfragen an den Dispatcher schicken und die Antwort im Flow weiterverwenden. Das folgende TypeScript‑Fragment zeigt den Kern:
+Unter `integrations/flowise-agentnn` liegt eine Beispielkomponente `AgentNN.ts`. Sie sendet Fragen an den Dispatcher und gibt das Ergebnis zurück. Der Kern sieht so aus:
 
 ```ts
 import axios from 'axios';
@@ -42,4 +42,4 @@ result = plugin.execute(
 )
 ```
 
-So kann ein Flowise‑Chatbot direkt in Agent‑NN Aufgaben bearbeiten oder Informationen abrufen.
+Kompiliere das Skript zu JavaScript und registriere es über die Flowise-UI. So kann ein Flowise‑Chatbot direkt in Agent‑NN Aufgaben bearbeiten oder Informationen abrufen. Optional lassen sich `method` und `timeout` an den Pluginaufruf übergeben.

--- a/docs/integrations/full_integration_plan.md
+++ b/docs/integrations/full_integration_plan.md
@@ -10,7 +10,7 @@ Dieser Plan beschreibt die nötigen Schritte, um Agent‑NN in beide Richtungen 
 
 ## 2. n8n Node für Agent‑NN
 
-1. Neues Paket unter `integrations/n8n-agentnn` mit TypeScript-Quellcode anlegen.
+1. Neues Paket unter `integrations/n8n-agentnn` mit TypeScript-Quellcode anlegen (bereits im Repository enthalten).
 2. Implementation eines `AgentNN` Nodes, der folgende Parameter besitzt:
    - `endpoint`: Basis-URL des API-Gateways
    - `task_type`: Art der Aufgabe (z. B. `chat`)
@@ -20,14 +20,14 @@ Dieser Plan beschreibt die nötigen Schritte, um Agent‑NN in beide Richtungen 
 
 ## 3. FlowiseAI Komponente
 
-1. Neues Modul `integrations/flowise-agentnn` mit einem Custom Component Script (`AgentNN.ts`).
+1. Neues Modul `integrations/flowise-agentnn` mit einem Custom Component Script (`AgentNN.ts`) (bereits im Repository enthalten).
 2. Das Script erlaubt die Konfiguration der Agent‑NN URL und weiterer Parameter.
 3. Eingehende Prompts werden an Agent‑NN weitergeleitet; die Antwort des Dispatchers wird als Chatbot-Antwort ausgegeben.
 4. Bereitstellung über das Flowise Plugin System.
 
 ## 4. Verbesserte Plugins in Agent‑NN
 
-- Erweiterung der Plugins `n8n_workflow` und `flowise_workflow` um optionale Auth‑Header sowie konfigurierbare Timeouts.
+- Erweiterung der Plugins `n8n_workflow` und `flowise_workflow` um optionale Auth‑Header, frei wählbare HTTP-Methoden sowie konfigurierbare Timeouts.
 - Dokumentation aller Felder in den Plugin-Manifests.
 - Beispielskript `run_plugin_task.py` aktualisieren, um beide Plugins komfortabel testen zu können.
 

--- a/docs/integrations/n8n.md
+++ b/docs/integrations/n8n.md
@@ -1,31 +1,29 @@
 # n8n Integration
 
-Die Workflow-Plattform [n8n](https://n8n.io/) kann Agent‑NN sowohl aufrufen als auch von Agent‑NN aus gestartet werden.
+Die Workflow-Plattform [n8n](https://n8n.io/) kann Agent‑NN sowohl aufrufen als auch von Agent‑NN aus gestartet werden. Eigene Nodes erleichtern die Kommunikation.
 
 ## Agent‑NN von n8n aus nutzen
 
-Für eine enge Anbindung empfiehlt sich ein eigener Node. Das folgende Beispiel zeigt ein minimales TypeScript-Snippet:
+### Eigener Node
+
+Ein Beispiel befindet sich unter `integrations/n8n-agentnn/AgentNN.node.ts`. Der Node leitet Aufgaben an den Dispatcher weiter. Der Kern sieht wie folgt aus:
 
 ```ts
 import { IExecuteFunctions } from 'n8n-core';
 import { IDataObject } from 'n8n-workflow';
+import axios from 'axios';
 
 export async function execute(this: IExecuteFunctions): Promise<IDataObject[]> {
   const endpoint = this.getNodeParameter('endpoint') as string;
   const taskType = this.getNodeParameter('taskType') as string;
-  const payload = this.getNodeParameter('payload') as object;
+  const payload = this.getNodeParameter('payload') as IDataObject;
 
-  const response = await this.helpers.request({
-    method: 'POST',
-    uri: `${endpoint}/task`,
-    body: {
-      task_type: taskType,
-      input: payload,
-    },
-    json: true,
+  const { data } = await axios.post(`${endpoint}/task`, {
+    task_type: taskType,
+    input: payload,
   });
 
-  return [response as IDataObject];
+  return [data as IDataObject];
 }
 ```
 
@@ -50,3 +48,5 @@ result = plugin.execute(
 ```
 
 Der Aufruf gibt die Antwort des Workflows zurück.
+
+Über die optionalen Parameter `method` und `timeout` lassen sich HTTP-Methode und Zeitlimit anpassen.

--- a/integrations/flowise-agentnn/AgentNN.ts
+++ b/integrations/flowise-agentnn/AgentNN.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+export default class AgentNN {
+  constructor(private endpoint: string) {}
+
+  async run(question: string): Promise<string> {
+    const { data } = await axios.post(`${this.endpoint}/task`, {
+      task_type: 'chat',
+      input: question,
+    });
+    return data.result as string;
+  }
+}

--- a/integrations/flowise-agentnn/README.md
+++ b/integrations/flowise-agentnn/README.md
@@ -1,0 +1,4 @@
+# Flowise AgentNN Component
+
+A simple Flowise component that sends user prompts to the Agent-NN dispatcher.
+Configure the `endpoint` parameter when registering the component in Flowise.

--- a/integrations/n8n-agentnn/AgentNN.node.ts
+++ b/integrations/n8n-agentnn/AgentNN.node.ts
@@ -1,0 +1,16 @@
+import { IExecuteFunctions } from 'n8n-core';
+import { IDataObject } from 'n8n-workflow';
+import axios from 'axios';
+
+export async function execute(this: IExecuteFunctions): Promise<IDataObject[]> {
+  const endpoint = this.getNodeParameter('endpoint') as string;
+  const taskType = this.getNodeParameter('taskType') as string;
+  const payload = this.getNodeParameter('payload') as IDataObject;
+
+  const { data } = await axios.post(`${endpoint}/task`, {
+    task_type: taskType,
+    input: payload,
+  });
+
+  return [data as IDataObject];
+}

--- a/integrations/n8n-agentnn/README.md
+++ b/integrations/n8n-agentnn/README.md
@@ -1,0 +1,4 @@
+# n8n AgentNN Node
+
+This directory contains a custom n8n node that forwards tasks to the Agent-NN API gateway.
+Install the package in your n8n instance and configure the `endpoint`, `taskType`, and `payload` parameters.

--- a/plugins/flowise_workflow/manifest.yaml
+++ b/plugins/flowise_workflow/manifest.yaml
@@ -1,3 +1,19 @@
 name: flowise_workflow
 version: 0.1
 summary: Invoke FlowiseAI chatflows via HTTP
+fields:
+  url:
+    type: string
+    description: Flowise endpoint or chatflow webhook
+  payload:
+    type: object
+    description: Optional JSON body for the request
+  headers:
+    type: object
+    description: Optional HTTP headers for authentication
+  method:
+    type: string
+    description: HTTP method to use, defaults to POST
+  timeout:
+    type: integer
+    description: Request timeout in seconds

--- a/plugins/flowise_workflow/plugin.py
+++ b/plugins/flowise_workflow/plugin.py
@@ -10,10 +10,12 @@ class Plugin(ToolPlugin):
         url = input.get("url")
         payload = input.get("payload", {})
         headers = input.get("headers", {})
+        method = input.get("method", "POST").upper()
+        timeout = input.get("timeout", 10)
         if not url:
             return {"error": "no url provided"}
         try:
-            resp = httpx.post(url, json=payload, headers=headers, timeout=10)
+            resp = httpx.request(method, url, json=payload, headers=headers, timeout=timeout)
             resp.raise_for_status()
             try:
                 data = resp.json()

--- a/plugins/n8n_workflow/manifest.yaml
+++ b/plugins/n8n_workflow/manifest.yaml
@@ -1,3 +1,19 @@
 name: n8n_workflow
 version: 0.1
 summary: Trigger workflows in n8n via HTTP requests
+fields:
+  url:
+    type: string
+    description: Endpoint of the n8n webhook or REST workflow
+  payload:
+    type: object
+    description: Arbitrary JSON payload sent in the request body
+  headers:
+    type: object
+    description: Optional HTTP headers for authentication
+  method:
+    type: string
+    description: HTTP method to use, defaults to POST
+  timeout:
+    type: integer
+    description: Request timeout in seconds

--- a/plugins/n8n_workflow/plugin.py
+++ b/plugins/n8n_workflow/plugin.py
@@ -4,16 +4,18 @@ from plugins import ToolPlugin
 
 
 class Plugin(ToolPlugin):
-    """Trigger an n8n workflow via HTTP POST."""
+    """Trigger an n8n workflow via HTTP request."""
 
     def execute(self, input: dict, context: dict) -> dict:
         url = input.get("url")
         payload = input.get("payload", {})
         headers = input.get("headers", {})
+        method = input.get("method", "POST").upper()
+        timeout = input.get("timeout", 10)
         if not url:
             return {"error": "no url provided"}
         try:
-            resp = httpx.post(url, json=payload, headers=headers, timeout=10)
+            resp = httpx.request(method, url, json=payload, headers=headers, timeout=timeout)
             resp.raise_for_status()
             try:
                 data = resp.json()

--- a/tests/test_n8n_flowise_plugin.py
+++ b/tests/test_n8n_flowise_plugin.py
@@ -3,21 +3,21 @@ from plugins.n8n_workflow.plugin import Plugin as N8NPlugin
 from plugins.flowise_workflow.plugin import Plugin as FlowisePlugin
 
 
-def _fake_post(url: str, json=None, headers=None, timeout=10):
-    return httpx.Response(200, json={"ok": True, "url": url})
+def _fake_request(method: str, url: str, json=None, headers=None, timeout=10):
+    return httpx.Response(200, json={"ok": True, "url": url, "method": method, "timeout": timeout})
 
 
 def test_n8n_plugin(monkeypatch):
-    monkeypatch.setattr(httpx, "post", _fake_post)
+    monkeypatch.setattr(httpx, "request", _fake_request)
     plugin = N8NPlugin()
-    result = plugin.execute({"url": "http://n8n.local/webhook"}, {})
+    result = plugin.execute({"url": "http://n8n.local/webhook", "method": "POST", "timeout": 5}, {})
     assert result["status"] == "success"
-    assert result["data"] == {"ok": True, "url": "http://n8n.local/webhook"}
+    assert result["data"] == {"ok": True, "url": "http://n8n.local/webhook", "method": "POST", "timeout": 5}
 
 
 def test_flowise_plugin(monkeypatch):
-    monkeypatch.setattr(httpx, "post", _fake_post)
+    monkeypatch.setattr(httpx, "request", _fake_request)
     plugin = FlowisePlugin()
-    result = plugin.execute({"url": "http://flowise.local/api"}, {})
+    result = plugin.execute({"url": "http://flowise.local/api", "method": "POST"}, {})
     assert result["status"] == "success"
-    assert result["data"] == {"ok": True, "url": "http://flowise.local/api"}
+    assert result["data"] == {"ok": True, "url": "http://flowise.local/api", "method": "POST", "timeout": 10}


### PR DESCRIPTION
## Summary
- extend n8n integration docs and add example node
- extend Flowise docs with component example
- update integration plan for n8n and Flowise
- mention node/component locations in AGENTS.md
- allow HTTP method and timeout options in the n8n and Flowise plugins
- document plugin fields
- add tests for the updated plugins

## Testing
- `ruff check .`
- `mypy mcp` *(fails: Cannot find implementation or library stub for fastapi etc.)*
- `pytest tests/test_n8n_flowise_plugin.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686509a92e04832482bab944a6c405b6