### PR TITLE
Enhance n8n & Flowise integration docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ Unabhängig von der Rolle gelten folgende übergreifende Regeln für den Codex-A
 - **Versionierung & Dependency Management:** Bei größeren Änderungen überprüfen, ob Version angepasst werden sollte. Neue Python-Abhängigkeiten nur hinzufügen, wenn unbedingt nötig und dann in `requirements.txt` bzw. `pyproject.toml` vermerken.  
 - **Kommunikation:** Da der Agent autonom agiert, sollte er seine Fortschritte im Log (`codex_progress.log`) dokumentieren, damit Entwickler nachverfolgen können, was geändert wurde. Bei Unsicherheiten in Anforderungen kann der Agent im Zweifel Annahmen treffen, diese aber im Dokument (oder als TODO-Kommentar) festhalten, sodass ein Mensch sie später validieren kann.
 - **Integrationen:** Plugins für n8n und FlowiseAI liegen unter `plugins/`. Beispielimplementierungen der Custom Nodes/Components findest du in `integrations/`. Ausführliche Hinweise und ein Integrationsplan sind in `docs/integrations/` dokumentiert. Bei Erweiterungen stets auf API-Kompatibilität achten und die optionale Übergabe von `method` und `timeout` berücksichtigen.
+- **Integrations-Builds:** n8n-Node und Flowise-Komponente sollten vor einer Veröffentlichung nach `dist/` kompiliert werden (mittels `tsc`). Die genauen Schritte sind in den Integrationsdokumenten beschrieben. Der `PluginManager` lädt die ausführbaren Tools zur Laufzeit aus dem Verzeichnis `plugins/`.
 
 *Ende der AGENTS.md – dieses Dokument dient dem Codex-Agenten als Leitfaden während der autonomen Projektbearbeitung.*
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ Run `npm run build` to create the static files in `frontend/dist/`.
 ## Integrations
 
 Agent-NN stellt Plugins für n8n und FlowiseAI bereit. Details finden sich in
-[docs/integrations](docs/integrations/index.md).
+[docs/integrations](docs/integrations/index.md). Die Beispielkomponenten lassen sich mit
+`npm install && npx tsc` in den jeweiligen Unterordnern kompilieren und anschließend
+in n8n bzw. Flowise registrieren.
 
 ## Tests & Beiträge
 

--- a/docs/integrations/flowise.md
+++ b/docs/integrations/flowise.md
@@ -43,3 +43,12 @@ result = plugin.execute(
 ```
 
 Kompiliere das Skript zu JavaScript und registriere es über die Flowise-UI. So kann ein Flowise‑Chatbot direkt in Agent‑NN Aufgaben bearbeiten oder Informationen abrufen. Optional lassen sich `method` und `timeout` an den Pluginaufruf übergeben.
+
+## Registrierung der Komponente
+
+1. Wechsle in das Verzeichnis `integrations/flowise-agentnn`.
+2. Installiere Abhängigkeiten mit `npm install` und führe `npx tsc` aus.
+3. Lade die erzeugte `dist/AgentNN.js` Datei in der Flowise-Administration hoch.
+4. Lege beim Einbinden der Komponente die URL deines Agent‑NN Gateways fest.
+
+Weitere Details enthält der [Integration Plan](full_integration_plan.md).

--- a/docs/integrations/full_integration_plan.md
+++ b/docs/integrations/full_integration_plan.md
@@ -16,14 +16,16 @@ Dieser Plan beschreibt die nötigen Schritte, um Agent‑NN in beide Richtungen 
    - `task_type`: Art der Aufgabe (z. B. `chat`)
    - `payload`: Freies JSON-Feld für Eingabedaten
 3. Der Node sendet eine POST-Anfrage an `/task` und gibt die JSON-Antwort zurück.
-4. Veröffentlichung als benutzerdefiniertes n8n-Paket (Installationsanleitung in der Doku).
+4. Führe `npm install` und anschließend `npx tsc` aus, um die JavaScript-Dateien in `dist/` zu erzeugen.
+5. Veröffentlichung als benutzerdefiniertes n8n-Paket (Installationsanleitung in der Doku).
 
 ## 3. FlowiseAI Komponente
 
 1. Neues Modul `integrations/flowise-agentnn` mit einem Custom Component Script (`AgentNN.ts`) (bereits im Repository enthalten).
 2. Das Script erlaubt die Konfiguration der Agent‑NN URL und weiterer Parameter.
 3. Eingehende Prompts werden an Agent‑NN weitergeleitet; die Antwort des Dispatchers wird als Chatbot-Antwort ausgegeben.
-4. Bereitstellung über das Flowise Plugin System.
+4. Nach `npm install` und `npx tsc` liegt die kompilierte Datei unter `dist/AgentNN.js`.
+5. Bereitstellung über das Flowise Plugin System.
 
 ## 4. Verbesserte Plugins in Agent‑NN
 

--- a/docs/integrations/n8n.md
+++ b/docs/integrations/n8n.md
@@ -50,3 +50,12 @@ result = plugin.execute(
 Der Aufruf gibt die Antwort des Workflows zurück.
 
 Über die optionalen Parameter `method` und `timeout` lassen sich HTTP-Methode und Zeitlimit anpassen.
+
+## Installation des Nodes
+
+1. Navigiere in das Verzeichnis `integrations/n8n-agentnn`.
+2. Führe `npm install` aus und kompiliere den TypeScript-Code mit `npx tsc`.
+3. Kopiere die erzeugten Dateien aus `dist/` in den `~/.n8n/custom` Ordner deiner n8n-Installation.
+4. Starte n8n neu, um den Node nutzen zu können.
+
+Weitere Hinweise zur Konfiguration findest du im [Integration Plan](full_integration_plan.md).

--- a/integrations/flowise-agentnn/README.md
+++ b/integrations/flowise-agentnn/README.md
@@ -1,4 +1,5 @@
 # Flowise AgentNN Component
 
 A simple Flowise component that sends user prompts to the Agent-NN dispatcher.
-Configure the `endpoint` parameter when registering the component in Flowise.
+After running `npm install` you can build the script with `npx tsc`.
+Upload the generated `dist/AgentNN.js` through the Flowise UI and set the `endpoint` parameter during registration.

--- a/integrations/flowise-agentnn/package.json
+++ b/integrations/flowise-agentnn/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "agentnn-flowise-component",
+  "version": "0.1.0",
+  "main": "dist/AgentNN.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.0",
+    "axios": "^1.6.0"
+  }
+}

--- a/integrations/flowise-agentnn/tsconfig.json
+++ b/integrations/flowise-agentnn/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true
+  },
+  "include": ["*.ts"]
+}

--- a/integrations/n8n-agentnn/README.md
+++ b/integrations/n8n-agentnn/README.md
@@ -1,4 +1,6 @@
 # n8n AgentNN Node
 
 This directory contains a custom n8n node that forwards tasks to the Agent-NN API gateway.
-Install the package in your n8n instance and configure the `endpoint`, `taskType`, and `payload` parameters.
+Run `npm install` followed by `npx tsc` to compile `AgentNN.node.ts` to JavaScript.
+Copy the resulting files from `dist/` to your `~/.n8n/custom` directory and restart n8n.
+Configure the `endpoint`, `taskType`, and `payload` parameters in the node settings.

--- a/integrations/n8n-agentnn/package.json
+++ b/integrations/n8n-agentnn/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "agentnn-n8n-node",
+  "version": "0.1.0",
+  "main": "dist/AgentNN.node.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.0",
+    "axios": "^1.6.0"
+  }
+}

--- a/integrations/n8n-agentnn/tsconfig.json
+++ b/integrations/n8n-agentnn/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary
- update AGENTS rules with build hint for integration packages
- document compilation and installation steps for the n8n node and the Flowise component
- link integration build instructions from README
- add TypeScript configs and package descriptors for the integration examples

## Testing
- `ruff check .`
- `mypy mcp` *(fails: missing modules)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68650c4f557c8324b18997732b53b29e