### PR TITLE
Improve Flowise component

### DIFF
--- a/docs/integrations/flowise.md
+++ b/docs/integrations/flowise.md
@@ -10,14 +10,23 @@ Unter `integrations/flowise-agentnn` liegt eine Beispielkomponente `AgentNN.ts`.
 import axios from 'axios';
 
 export default class AgentNN {
-  constructor(private endpoint: string) {}
+  constructor(
+    private endpoint: string,
+    private taskType = 'chat',
+    private headers: Record<string, string> = {},
+    private timeout = 10000,
+  ) {}
 
-  async run(question: string) {
-    const { data } = await axios.post(`${this.endpoint}/task`, {
-      task_type: 'chat',
-      input: question,
-    });
-    return data.result;
+  async run(payload: unknown) {
+    const { data } = await axios.post(
+      `${this.endpoint}/task`,
+      {
+        task_type: this.taskType,
+        input: payload,
+      },
+      { headers: this.headers, timeout: this.timeout },
+    );
+    return data.result ?? data;
   }
 }
 ```
@@ -49,6 +58,7 @@ Kompiliere das Skript zu JavaScript und registriere es über die Flowise-UI. So 
 1. Wechsle in das Verzeichnis `integrations/flowise-agentnn`.
 2. Installiere Abhängigkeiten mit `npm install` und führe `npx tsc` aus.
 3. Lade die erzeugte `dist/AgentNN.js` Datei in der Flowise-Administration hoch.
-4. Lege beim Einbinden der Komponente die URL deines Agent‑NN Gateways fest.
+4. Lege beim Einbinden der Komponente die URL deines Agent‑NN Gateways fest und
+   optional weitere Parameter wie `taskType`, Header oder Timeout.
 
 Weitere Details enthält der [Integration Plan](full_integration_plan.md).

--- a/integrations/flowise-agentnn/AgentNN.ts
+++ b/integrations/flowise-agentnn/AgentNN.ts
@@ -1,13 +1,25 @@
 import axios from 'axios';
 
 export default class AgentNN {
-  constructor(private endpoint: string) {}
+  constructor(
+    private endpoint: string,
+    private taskType = 'chat',
+    private headers: Record<string, string> = {},
+    private timeout = 10000
+  ) {}
 
-  async run(question: string): Promise<string> {
-    const { data } = await axios.post(`${this.endpoint}/task`, {
-      task_type: 'chat',
-      input: question,
-    });
-    return data.result as string;
+  async run(payload: unknown): Promise<any> {
+    const { data } = await axios.post(
+      `${this.endpoint}/task`,
+      {
+        task_type: this.taskType,
+        input: payload,
+      },
+      {
+        headers: this.headers,
+        timeout: this.timeout,
+      }
+    );
+    return data.result ?? data;
   }
 }

--- a/integrations/flowise-agentnn/README.md
+++ b/integrations/flowise-agentnn/README.md
@@ -1,5 +1,7 @@
 # Flowise AgentNN Component
 
-A simple Flowise component that sends user prompts to the Agent-NN dispatcher.
-After running `npm install` you can build the script with `npx tsc`.
-Upload the generated `dist/AgentNN.js` through the Flowise UI and set the `endpoint` parameter during registration.
+A Flowise component that forwards input to the Agent-NN API gateway.
+Run `npm install` and then `npx tsc` to compile the script.
+Upload the generated `dist/AgentNN.js` through the Flowise UI and configure the
+`endpoint` of your Agent-NN instance. Optional parameters allow you to change
+`taskType`, send HTTP headers and adjust the request timeout.


### PR DESCRIPTION
## Summary
- expand Flowise integration code to allow optional task type, headers and timeout
- document new options in the integration docs
- update Flowise component README

## Testing
- `npm install && npx tsc` in `integrations/flowise-agentnn`
- `pytest -q` *(fails: 135 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6865113763b08324b9f7f60e9cdce586