### PR TITLE
Improve n8n plugin

### DIFF
--- a/docs/integrations/n8n.md
+++ b/docs/integrations/n8n.md
@@ -11,23 +11,35 @@ Ein Beispiel befindet sich unter `integrations/n8n-agentnn/AgentNN.node.ts`. Der
 ```ts
 import { IExecuteFunctions } from 'n8n-core';
 import { IDataObject } from 'n8n-workflow';
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 
 export async function execute(this: IExecuteFunctions): Promise<IDataObject[]> {
   const endpoint = this.getNodeParameter('endpoint') as string;
   const taskType = this.getNodeParameter('taskType') as string;
   const payload = this.getNodeParameter('payload') as IDataObject;
+  const method = (this.getNodeParameter('method', 0, 'POST') as string).toUpperCase();
+  const headers = (this.getNodeParameter('headers', 0, {}) as IDataObject) as Record<string, string>;
+  const timeout = this.getNodeParameter('timeout', 0, 10000) as number;
 
-  const { data } = await axios.post(`${endpoint}/task`, {
-    task_type: taskType,
-    input: payload,
-  });
+  const options: AxiosRequestConfig = {
+    method,
+    url: `${endpoint}/task`,
+    data: {
+      task_type: taskType,
+      input: payload,
+    },
+    headers,
+    timeout,
+  };
+
+  const { data } = await axios.request(options);
 
   return [data as IDataObject];
 }
 ```
 
 Dieses Skript kann als Custom Node in n8n eingebunden werden und sendet Aufgaben direkt an das Agent‑NN API‑Gateway.
+Dabei können optionale Parameter wie `method`, `headers` und `timeout` gesetzt werden, um HTTP-Methode, Header und Zeitlimit zu steuern.
 
 ## Agent‑NN ruft n8n Workflows auf
 

--- a/integrations/n8n-agentnn/AgentNN.node.ts
+++ b/integrations/n8n-agentnn/AgentNN.node.ts
@@ -1,16 +1,27 @@
 import { IExecuteFunctions } from 'n8n-core';
 import { IDataObject } from 'n8n-workflow';
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 
 export async function execute(this: IExecuteFunctions): Promise<IDataObject[]> {
   const endpoint = this.getNodeParameter('endpoint') as string;
   const taskType = this.getNodeParameter('taskType') as string;
   const payload = this.getNodeParameter('payload') as IDataObject;
+  const method = (this.getNodeParameter('method', 0, 'POST') as string).toUpperCase();
+  const headers = (this.getNodeParameter('headers', 0, {}) as IDataObject) as Record<string, string>;
+  const timeout = this.getNodeParameter('timeout', 0, 10000) as number;
 
-  const { data } = await axios.post(`${endpoint}/task`, {
-    task_type: taskType,
-    input: payload,
-  });
+  const options: AxiosRequestConfig = {
+    method,
+    url: `${endpoint}/task`,
+    data: {
+      task_type: taskType,
+      input: payload,
+    },
+    headers,
+    timeout,
+  };
+
+  const { data } = await axios.request(options);
 
   return [data as IDataObject];
 }

--- a/integrations/n8n-agentnn/README.md
+++ b/integrations/n8n-agentnn/README.md
@@ -3,4 +3,4 @@
 This directory contains a custom n8n node that forwards tasks to the Agent-NN API gateway.
 Run `npm install` followed by `npx tsc` to compile `AgentNN.node.ts` to JavaScript.
 Copy the resulting files from `dist/` to your `~/.n8n/custom` directory and restart n8n.
-Configure the `endpoint`, `taskType`, and `payload` parameters in the node settings.
+Configure the `endpoint`, `taskType`, `payload`, `method`, `headers`, and `timeout` parameters in the node settings.


### PR DESCRIPTION
## Summary
- extend n8n node with optional request parameters
- document new parameters in README and integration guide

## Testing
- `ruff check .`
- `mypy mcp` *(fails: Module not found errors)*
- `pytest -q` *(fails: test collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_686511632a8c83249fc79a187ad34466