### PR TITLE
Fix n8n node build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,7 @@ keys/
 *.tmp
 .ipynb_checkpoints/
 /frontend/node_modules/
+integrations/n8n-agentnn/node_modules/
+integrations/n8n-agentnn/dist/
 *.env
 frontend/agent-ui/dist/

--- a/integrations/n8n-agentnn/AgentNN.node.ts
+++ b/integrations/n8n-agentnn/AgentNN.node.ts
@@ -1,31 +1,10 @@
-import axios from 'axios';
-
-export async function execute(this: any): Promise<any[]> {
-  const endpoint = this.getNodeParameter('endpoint') as string;
-  const taskType = this.getNodeParameter('taskType') as string;
-  const payload = this.getNodeParameter('payload') as any;
-  const headers = (this.getNodeParameter('headers', 0, {}) as any) || {};
-  const method = (this.getNodeParameter('method', 0, 'POST') as string).toUpperCase();
-  const timeout = this.getNodeParameter('timeout', 0, 10000) as number;
-
-  const { data } = await axios.request({
-    url: `${endpoint}/task`,
-    method,
-    data: {
-      task_type: taskType,
-      input: payload,
-    },
-    headers,
-    timeout,
-  });
-
-  return [data as any];
-import { IExecuteFunctions } from 'n8n-core';
+import { IExecuteFunctions } from 'n8n-workflow';
 import {
   IDataObject,
   INodeExecutionData,
   INodeType,
   INodeTypeDescription,
+  NodeConnectionType,
 } from 'n8n-workflow';
 import axios, { AxiosRequestConfig } from 'axios';
 
@@ -39,8 +18,8 @@ export class AgentNN implements INodeType {
     defaults: {
       name: 'AgentNN',
     },
-    inputs: ['main'],
-    outputs: ['main'],
+    inputs: [NodeConnectionType.Main],
+    outputs: [NodeConnectionType.Main],
     properties: [
       {
         displayName: 'Endpoint',
@@ -102,9 +81,9 @@ export class AgentNN implements INodeType {
   };
 
   async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-    const endpoint = this.getNodeParameter('endpoint') as string;
-    const taskType = this.getNodeParameter('taskType') as string;
-    const payload = this.getNodeParameter('payload') as IDataObject;
+    const endpoint = this.getNodeParameter('endpoint', 0) as unknown as string;
+    const taskType = this.getNodeParameter('taskType', 0) as unknown as string;
+    const payload = this.getNodeParameter('payload', 0) as unknown as IDataObject;
     const path = this.getNodeParameter('path', 0, '/task') as string;
     const method = (this.getNodeParameter('method', 0, 'POST') as string).toUpperCase();
     const headers = (this.getNodeParameter('headers', 0, {}) as IDataObject) as Record<string, string>;

--- a/integrations/n8n-agentnn/README.md
+++ b/integrations/n8n-agentnn/README.md
@@ -1,6 +1,30 @@
 # n8n AgentNN Node
 
-This directory contains a custom n8n node that forwards tasks to the Agent-NN API gateway.
-Run `npm install` followed by `npx tsc` to compile `AgentNN.node.ts` to JavaScript.
-Copy the resulting files from `dist/` to your `~/.n8n/custom` directory and restart n8n.
-Configure the `endpoint`, `taskType`, `method`, headers, timeout and `payload` parameters in the node settings.
+This directory contains a custom n8n node which sends tasks to the Agent‑NN API
+gateway. The node can be used to integrate Agent‑NN into your n8n workflows.
+
+## Build
+
+```bash
+npm install
+npm run build
+```
+
+The command creates the compiled files in the `dist/` directory. Copy these
+files into your local `~/.n8n/custom` directory and restart n8n so that the node
+is loaded.
+
+## Usage
+
+In the node parameters specify:
+
+- **endpoint** – Base URL of the Agent‑NN API gateway.
+- **taskType** – Type of task to execute (e.g. `chat`).
+- **payload** – JSON payload passed as the `input` field.
+- **path** – Optional API path appended to the endpoint (defaults to `/task`).
+- **method** – HTTP method (`POST` or `GET`).
+- **headers** – Optional additional HTTP headers as JSON object.
+- **timeout** – Request timeout in milliseconds.
+
+When executed, the node forwards the request to Agent‑NN and returns the API
+response.


### PR DESCRIPTION
## Summary
- fix TS implementation of the n8n `AgentNN` node
- document build and usage for the node
- update n8n integration docs
- ignore integration build artefacts

## Testing
- `npm run build` in `integrations/n8n-agentnn`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68651db0a2fc8324a0ba389d8a8979c4