### PR TITLE
Improve integration docs and release checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ Unabhängig von der Rolle gelten folgende übergreifende Regeln für den Codex-A
 - **Kommunikation:** Da der Agent autonom agiert, sollte er seine Fortschritte im Log (`codex_progress.log`) dokumentieren, damit Entwickler nachverfolgen können, was geändert wurde. Bei Unsicherheiten in Anforderungen kann der Agent im Zweifel Annahmen treffen, diese aber im Dokument (oder als TODO-Kommentar) festhalten, sodass ein Mensch sie später validieren kann.
 - **Integrationen:** Plugins für n8n und FlowiseAI liegen unter `plugins/`. Beispielimplementierungen der Custom Nodes/Components findest du in `integrations/`. Ausführliche Hinweise und ein Integrationsplan sind in `docs/integrations/` dokumentiert. Bei Erweiterungen stets auf API-Kompatibilität achten und die optionale Übergabe von `task_type`, `path`, `method`, `headers` und `timeout` berücksichtigen.
 - **Integrations-Builds:** n8n-Node und Flowise-Komponente **müssen** vor jeder Veröffentlichung mit `npm install && npx tsc` in das Verzeichnis `dist/` kompiliert werden. Der PluginManager lädt ausschließlich die erzeugten JavaScript-Dateien aus `plugins/` bzw. den Integrationsordnern. Die genauen Schritte sind in den Integrationsdokumenten beschrieben.
+- **Fehleranalyse Integrationen:** Bei `npm install` oder `tsc` auftretenden Fehlern zuerst die Netzwerkverbindung überprüfen. In Offline-Umgebungen lokale Caches oder interne Registries nutzen und Dateipfade auf Schreibrechte prüfen.
 
 *Ende der AGENTS.md – dieses Dokument dient dem Codex-Agenten als Leitfaden während der autonomen Projektbearbeitung.*
 

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ Run `npm run build` to create the static files in `frontend/dist/`.
 ## Integrations
 
 Agent-NN stellt Plugins für n8n und FlowiseAI bereit. Details finden sich in
-[docs/integrations](docs/integrations/index.md). Die Beispielkomponenten lassen sich mit
-`npm install && npx tsc` in den jeweiligen Unterordnern kompilieren und anschließend
+[docs/integrations](docs/integrations/index.md). Schnelleinstiege stehen in den Abschnitten [n8n Quick Start](docs/integrations/n8n.md#quick-start) und [Flowise Quick Start](docs/integrations/flowise.md#quick-start).
+Die Beispielkomponenten lassen sich mit `npm install && npx tsc` in den jeweiligen Unterordnern kompilieren und anschließend
 in n8n bzw. Flowise registrieren. Der PluginManager lädt nur die JavaScript-Dateien,
 daher müssen die Komponenten vor einer Veröffentlichung stets gebaut werden. Der vollständige Ablauf ist im
 [Full Integration Plan](docs/integrations/full_integration_plan.md) beschrieben.
@@ -174,7 +174,11 @@ Sämtliche Integrationen akzeptieren optionale Parameter wie `path`, `method`,
 
 ## Tests & Beiträge
 
-Bevor du einen Pull Request erstellst, führe bitte `ruff`, `mypy` und `pytest` aus. Details zum Entwicklungsprozess findest du in [CONTRIBUTING.md](CONTRIBUTING.md) sowie im Dokument [docs/test_strategy.md](docs/test_strategy.md).
+Bevor du einen Pull Request erstellst, führe bitte `ruff`, `mypy` und `pytest` aus. Details zum Entwicklungsprozess findest du in [CONTRIBUTING.md](CONTRIBUTING.md) sowie im Dokument [docs/test_strategy.md](docs/test_strategy.md). Sollten Module fehlen, können lokale Wheels oder ein internes Paketmirror verwendet werden.
+
+## Releases
+
+Der komplette Ablauf für neue Versionen ist im [Release Checklist](docs/release_checklist.md) beschrieben.
 
 ## Monitoring & Maintenance
 

--- a/docs/integrations/flowise.md
+++ b/docs/integrations/flowise.md
@@ -36,6 +36,18 @@ export default class AgentNN {
 
 Diese Komponente wird in Flowise eingebunden und erlaubt es, Benutzeranfragen direkt an Agent‑NN zu delegieren.
 
+## Quick Start
+
+```bash
+cd integrations/flowise-agentnn
+npm install
+npx tsc
+# Danach die Datei dist/AgentNN.js in Flowise hochladen
+```
+
+Nach dem Upload kann die Komponente sofort verwendet werden. Konfiguriere die
+Basis-URL von Agent‑NN sowie optionale Header oder ein anderes Timeout.
+
 ## Flowise Workflows aus Agent‑NN anstoßen
 
 Das Plugin `flowise_workflow` ruft HTTP‑basierte Chatflows auf. Neben einem Payload können optionale Header, die HTTP-Methode und ein Timeout übergeben werden:
@@ -74,3 +86,9 @@ Stelle deshalb sicher, dass `npm install` und `npx tsc` vor jeder Veröffentlich
 ausgeführt wurden.
 
 Weitere Details enthält der [Integration Plan](full_integration_plan.md).
+
+## Troubleshooting
+
+- **Installationsfehler**: Nutze einen internen npm-Mirror, falls `npm install` wegen fehlender Internetverbindung scheitert.
+- **Komponente erscheint nicht**: Prüfe, ob die Datei `dist/AgentNN.js` korrekt hochgeladen wurde und Flowise neu gestartet ist.
+- **API-Timeouts**: Erhöhe das `timeout` in der Komponente oder teste den Endpoint separat mit `curl`.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -4,4 +4,6 @@ Dieses Kapitel beschreibt, wie Agent-NN mit externen Tools gekoppelt werden kann
 
 Für die Beispielintegration ist es erforderlich, die TypeScript-Dateien zunächst mit `npm install` und `npx tsc` zu kompilieren. Die erzeugten JavaScript-Dateien werden anschließend vom jeweiligen PluginManager geladen.
 
+Schnelleinstiege findest du in den jeweiligen Kapiteln [n8n](n8n.md#quick-start) und [FlowiseAI](flowise.md#quick-start).
+
 Eine ausführliche Roadmap zur beidseitigen Integration findet sich in [full_integration_plan.md](full_integration_plan.md).

--- a/docs/integrations/n8n.md
+++ b/docs/integrations/n8n.md
@@ -54,6 +54,20 @@ export class AgentNN implements INodeType {
 Dieses Skript kann als Custom Node in n8n eingebunden werden und sendet Aufgaben direkt an das Agent‑NN API‑Gateway.
 Dabei können optionale Parameter wie `path`, `method`, `headers`, `timeout` und `auth` gesetzt werden, um URL-Pfad, HTTP-Methode, Header, Zeitlimit und Basis-Auth zu steuern.
 
+## Quick Start
+
+Schneller Einstieg zum Testen des Nodes:
+
+```bash
+cd integrations/n8n-agentnn
+npm install
+npx tsc
+cp dist/* ~/.n8n/custom/
+n8n start
+```
+
+Nach dem Kopieren der Dateien erscheint der Node im Editor unter `AgentNN`.
+
 ## Agent‑NN ruft n8n Workflows auf
 
 Das Python‑Plugin `n8n_workflow` erlaubt es, beliebige Webhook‑ oder REST‑Workflows anzusprechen. Neben Headern und Payloads lassen sich auch die HTTP-Methode, ein Timeout und optionale Basic‑Auth-Daten definieren:
@@ -89,3 +103,10 @@ Der Aufruf gibt die Antwort des Workflows zurück.
 Vor einer Veröffentlichung muss der Node immer nach `dist/` kompiliert werden. Der PluginManager lädt ausschließlich die JavaScript-Dateien.
 
 Weitere Hinweise zur Konfiguration findest du im [Integration Plan](full_integration_plan.md).
+
+## Troubleshooting
+
+- **Fehlende Module**: Schlägt `npm install` fehl, prüfe die Proxy-Einstellungen oder verwende ein internes npm-Registry.
+- **Keine Ausführung**: Wird der Node nicht angezeigt, kontrolliere, ob die Dateien unter `~/.n8n/custom` die Endung `.js` besitzen und n8n neu gestartet wurde.
+- **Netzwerkprobleme**: Bei Verbindungsfehlern setze das Feld `timeout` höher oder teste die URL per `curl`.
+- **Offline-Umgebungen**: Nutze einen lokalen npm-Cache (z.B. `npm config set cache /path/to/cache`) oder spiegel die Pakete intern.

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -1,0 +1,34 @@
+# Release Checklist
+
+Diese Liste hilft dabei, eine neue Version von Agent-NN vorzubereiten und zu veröffentlichen.
+
+1. **Tests ausführen**
+   ```bash
+   ruff check .
+   mypy .
+   pytest -q
+   ```
+   Bei fehlenden Abhängigkeiten verwende lokale Wheels oder ein internes Paketmirror.
+
+2. **Integrationen bauen**
+   ```bash
+   cd integrations/n8n-agentnn && npm install && npx tsc && cd -
+   cd integrations/flowise-agentnn && npm install && npx tsc && cd -
+   ```
+   Die erzeugten Dateien liegen in den jeweiligen `dist/`-Ordnern und müssen vor dem Release hochgeladen werden.
+
+3. **Version aktualisieren**
+   - `VERSION` Datei anpassen
+   - `CHANGELOG.md` ergänzen
+
+4. **Git-Tag setzen**
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+5. **Artefakte verteilen**
+   - JavaScript-Dateien in den Plugin-Manager laden
+   - Docker-Images bauen und in die Registry pushen
+
+Diese Schritte stellen sicher, dass ein Release reproduzierbar erstellt wird.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
     - CI/CD: development/cicd.md
     - Nx Python Plugin: development/nxlv-python.md
     - Release Notes: development/releases.md
+    - Release Checklist: release_checklist.md
   - Deployment:
     - Docker: deployment/docker.md
     - Kubernetes: deployment/kubernetes.md


### PR DESCRIPTION
## Summary
- document quick start for n8n and Flowise integrations
- add troubleshooting hints for integration builds
- reference quick start and release checklist in README
- provide release checklist document
- mention integration error analysis in AGENTS guidelines

## Testing
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub)*
- `pytest -q` *(fails: ImportError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6865279d49c08324a5698a4742b59fd5