### PR TITLE
Implement OpenHands conversation API

### DIFF
--- a/agents/openhands/base_openhands_agent.py
+++ b/agents/openhands/base_openhands_agent.py
@@ -7,104 +7,103 @@ from datetime import datetime
 from utils.logging_util import LoggerMixin
 from agents.worker_agent import WorkerAgent
 
+
 class OpenHandsAgent(WorkerAgent, LoggerMixin):
     """Base agent for OpenHands integration."""
-    
-    def __init__(self,
-                 name: str,
-                 api_url: Optional[str] = None,
-                 github_token: Optional[str] = None):
+
+    def __init__(
+        self,
+        name: str,
+        api_url: Optional[str] = None,
+        github_token: Optional[str] = None,
+    ):
         """Initialize OpenHands agent.
-        
+
         Args:
             name: Agent name
             api_url: OpenHands API URL
             github_token: GitHub token for API access
         """
         super().__init__(name=name)
-        self.api_url = api_url or os.getenv("OPENHANDS_API_URL", "http://localhost:8000")
+        self.api_url = api_url or os.getenv(
+            "OPENHANDS_API_URL", "http://localhost:8000"
+        )
         self.github_token = github_token or os.getenv("GITHUB_TOKEN")
-        
+
         if not self.github_token:
             raise ValueError("GitHub token is required")
-            
+
         # Initialize session
         self.session = None
-        
+
     async def initialize(self):
         """Initialize HTTP session."""
         if not self.session:
             self.session = aiohttp.ClientSession(
                 headers={
                     "Authorization": f"Bearer {self.github_token}",
-                    "Content-Type": "application/json"
+                    "Content-Type": "application/json",
                 }
             )
-            
+
     async def cleanup(self):
         """Clean up resources."""
         if self.session:
             await self.session.close()
             self.session = None
-            
-    async def submit_code(self,
-                         code: str,
-                         language: str,
-                         task_description: str,
-                         requirements: Optional[List[str]] = None) -> Dict[str, Any]:
+
+    async def submit_code(
+        self,
+        code: str,
+        language: str,
+        task_description: str,
+        requirements: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
         """Submit code for execution and testing.
-        
+
         Args:
             code: Code to execute
             language: Programming language
             task_description: Description of the task
             requirements: Optional list of requirements
-            
+
         Returns:
             Dict[str, Any]: Submission results
         """
         await self.initialize()
-        
+
         data = {
             "code": code,
             "language": language,
             "task_description": task_description,
-            "requirements": requirements or []
+            "requirements": requirements or [],
         }
-        
-        async with self.session.post(
-            f"{self.api_url}/execute",
-            json=data
-        ) as response:
+
+        async with self.session.post(f"{self.api_url}/execute", json=data) as response:
             if response.status == 200:
                 result = await response.json()
                 self.log_event(
-                    "code_submitted",
-                    {
-                        "language": language,
-                        "code_length": len(code)
-                    }
+                    "code_submitted", {"language": language, "code_length": len(code)}
                 )
                 return result
             else:
                 error = await response.text()
                 self.log_error(
-                    Exception(f"Failed to submit code: {error}"),
-                    {"language": language}
+                    Exception(f"Failed to submit code: {error}"), {"language": language}
                 )
                 raise Exception(f"Failed to submit code: {error}")
-                
+
     async def get_execution_result(self, execution_id: str) -> Dict[str, Any]:
         """Get execution results.
-        
+
         Args:
             execution_id: Execution ID
-            
+
         Returns:
             Dict[str, Any]: Execution results
         """
         await self.initialize()
-        
+
         async with self.session.get(
             f"{self.api_url}/executions/{execution_id}"
         ) as response:
@@ -114,21 +113,20 @@ class OpenHandsAgent(WorkerAgent, LoggerMixin):
                 error = await response.text()
                 self.log_error(
                     Exception(f"Failed to get execution results: {error}"),
-                    {"execution_id": execution_id}
+                    {"execution_id": execution_id},
                 )
                 raise Exception(f"Failed to get execution results: {error}")
-                
-    async def wait_for_execution(self,
-                               execution_id: str,
-                               timeout: float = 300,
-                               poll_interval: float = 2) -> Dict[str, Any]:
+
+    async def wait_for_execution(
+        self, execution_id: str, timeout: float = 300, poll_interval: float = 2
+    ) -> Dict[str, Any]:
         """Wait for execution completion.
-        
+
         Args:
             execution_id: Execution ID
             timeout: Maximum wait time in seconds
             poll_interval: Time between polls in seconds
-            
+
         Returns:
             Dict[str, Any]: Execution results
         """
@@ -137,131 +135,176 @@ class OpenHandsAgent(WorkerAgent, LoggerMixin):
             result = await self.get_execution_result(execution_id)
             if result["status"] in ["completed", "failed", "error"]:
                 return result
-                
+
             # Check timeout
             elapsed = (datetime.now() - start_time).total_seconds()
             if elapsed > timeout:
                 raise TimeoutError(f"Execution {execution_id} timed out")
-                
+
             await asyncio.sleep(poll_interval)
-            
-    async def submit_and_wait(self,
-                            code: str,
-                            language: str,
-                            task_description: str,
-                            requirements: Optional[List[str]] = None,
-                            timeout: float = 300) -> Dict[str, Any]:
+
+    async def submit_and_wait(
+        self,
+        code: str,
+        language: str,
+        task_description: str,
+        requirements: Optional[List[str]] = None,
+        timeout: float = 300,
+    ) -> Dict[str, Any]:
         """Submit code and wait for results.
-        
+
         Args:
             code: Code to execute
             language: Programming language
             task_description: Description of the task
             requirements: Optional list of requirements
             timeout: Maximum wait time in seconds
-            
+
         Returns:
             Dict[str, Any]: Execution results
         """
         # Submit code
         submission = await self.submit_code(
-            code,
-            language,
-            task_description,
-            requirements
+            code, language, task_description, requirements
         )
-        
+
         # Wait for results
         return await self.wait_for_execution(
-            submission["execution_id"],
-            timeout=timeout
+            submission["execution_id"], timeout=timeout
         )
-        
+
     async def get_supported_languages(self) -> List[str]:
         """Get list of supported programming languages.
-        
+
         Returns:
             List[str]: Supported languages
         """
         await self.initialize()
-        
-        async with self.session.get(
-            f"{self.api_url}/languages"
-        ) as response:
+
+        async with self.session.get(f"{self.api_url}/languages") as response:
             if response.status == 200:
                 return await response.json()
             else:
                 error = await response.text()
                 self.log_error(
-                    Exception(f"Failed to get supported languages: {error}"),
-                    {}
+                    Exception(f"Failed to get supported languages: {error}"), {}
                 )
                 raise Exception(f"Failed to get supported languages: {error}")
-                
+
     async def get_system_status(self) -> Dict[str, Any]:
         """Get OpenHands system status.
-        
+
         Returns:
             Dict[str, Any]: System status
         """
         await self.initialize()
-        
-        async with self.session.get(
-            f"{self.api_url}/status"
-        ) as response:
+
+        async with self.session.get(f"{self.api_url}/status") as response:
             if response.status == 200:
                 return await response.json()
             else:
                 error = await response.text()
-                self.log_error(
-                    Exception(f"Failed to get system status: {error}"),
-                    {}
-                )
+                self.log_error(Exception(f"Failed to get system status: {error}"), {})
                 raise Exception(f"Failed to get system status: {error}")
-                
-    async def report_issue(self,
-                         title: str,
-                         description: str,
-                         execution_id: Optional[str] = None,
-                         logs: Optional[str] = None) -> Dict[str, Any]:
+
+    async def report_issue(
+        self,
+        title: str,
+        description: str,
+        execution_id: Optional[str] = None,
+        logs: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Report issue to OpenHands.
-        
+
         Args:
             title: Issue title
             description: Issue description
             execution_id: Optional execution ID
             logs: Optional logs
-            
+
         Returns:
             Dict[str, Any]: Issue details
         """
         await self.initialize()
-        
+
         data = {
             "title": title,
             "description": description,
             "execution_id": execution_id,
-            "logs": logs
+            "logs": logs,
         }
-        
-        async with self.session.post(
-            f"{self.api_url}/issues",
-            json=data
-        ) as response:
+
+        async with self.session.post(f"{self.api_url}/issues", json=data) as response:
             if response.status == 201:
                 issue = await response.json()
                 self.log_event(
-                    "issue_reported",
-                    {
-                        "title": title,
-                        "execution_id": execution_id
-                    }
+                    "issue_reported", {"title": title, "execution_id": execution_id}
                 )
                 return issue
             else:
                 error = await response.text()
                 self.log_error(
-                    Exception(f"Failed to report issue: {error}"),
-                    {"title": title}
+                    Exception(f"Failed to report issue: {error}"), {"title": title}
                 )
                 raise Exception(f"Failed to report issue: {error}")
+
+    async def start_conversation(self, initial_user_msg: str) -> Dict[str, Any]:
+        """Start a new conversation."""
+        await self.initialize()
+        data = {"initial_user_msg": initial_user_msg}
+        async with self.session.post(
+            f"{self.api_url}/conversations", json=data
+        ) as response:
+            if response.status == 200:
+                return await response.json()
+            else:
+                error = await response.text()
+                raise Exception(f"Failed to start conversation: {error}")
+
+    async def list_conversations(self) -> List[str]:
+        """List conversations."""
+        await self.initialize()
+        async with self.session.get(f"{self.api_url}/conversations") as response:
+            if response.status == 200:
+                return await response.json()
+            else:
+                error = await response.text()
+                raise Exception(f"Failed to list conversations: {error}")
+
+    async def get_trajectory(self, conversation_id: str) -> Dict[str, Any]:
+        """Get conversation trajectory."""
+        await self.initialize()
+        async with self.session.get(
+            f"{self.api_url}/conversations/{conversation_id}/trajectory"
+        ) as response:
+            if response.status == 200:
+                return await response.json()
+            else:
+                error = await response.text()
+                raise Exception(f"Failed to get trajectory: {error}")
+
+    async def list_files(self, conversation_id: str) -> List[str]:
+        """List files produced by conversation."""
+        await self.initialize()
+        async with self.session.get(
+            f"{self.api_url}/conversations/{conversation_id}/list-files"
+        ) as response:
+            if response.status == 200:
+                return await response.json()
+            else:
+                error = await response.text()
+                raise Exception(f"Failed to list files: {error}")
+
+    async def select_file(self, conversation_id: str, file: str) -> Dict[str, str]:
+        """Retrieve file content from conversation."""
+        await self.initialize()
+        params = {"file": file}
+        async with self.session.get(
+            f"{self.api_url}/conversations/{conversation_id}/select-file",
+            params=params,
+        ) as response:
+            if response.status == 200:
+                return await response.json()
+            else:
+                error = await response.text()
+                raise Exception(f"Failed to select file: {error}")

--- a/openhands_api/server.py
+++ b/openhands_api/server.py
@@ -11,6 +11,8 @@ import os
 from utils.api_utils import api_route
 from datetime import datetime, timedelta
 from utils.logging_util import LoggerMixin
+from pathlib import Path
+
 
 # Models
 class CodeExecution(BaseModel):
@@ -19,10 +21,12 @@ class CodeExecution(BaseModel):
     task_description: str
     requirements: Optional[List[str]] = Field(default_factory=list)
 
+
 class DockerBuild(BaseModel):
     dockerfile: str
     context: Dict[str, str]
     tag: str
+
 
 class DockerRun(BaseModel):
     image: str
@@ -31,58 +35,72 @@ class DockerRun(BaseModel):
     ports: Dict[str, str] = Field(default_factory=dict)
     volumes: Dict[str, str] = Field(default_factory=dict)
 
+
 class ComposeDeployment(BaseModel):
     compose_file: str
     stack_name: str
     environment: Dict[str, str] = Field(default_factory=dict)
 
+
 class ServiceScale(BaseModel):
     service: str
     replicas: int
 
+
+# Conversation models
+class ConversationStart(BaseModel):
+    initial_user_msg: str
+
+
 # API Server
 class OpenHandsAPI(FastAPI, LoggerMixin):
     """OpenHands API server."""
-    
+
     def __init__(self):
         """Initialize API server."""
         super().__init__(title="OpenHands API")
         LoggerMixin.__init__(self)
-        
+
         # Security
         self.security = HTTPBearer()
         self.secret_key = os.getenv("JWT_SECRET_KEY")
         if not self.secret_key:
             raise ValueError("JWT_SECRET_KEY environment variable is required")
-            
+
         # Docker client
         self.docker = docker.from_env()
-        
+
+        # Conversation storage
+        self.conversations_dir = Path(
+            os.getenv("OPENHANDS_CONVERSATIONS_DIR", "/tmp/openhands_conversations")
+        )
+        self.conversations_dir.mkdir(parents=True, exist_ok=True)
+
         # Redis for task queue
         self.redis_url = os.getenv("REDIS_URL", "redis://localhost")
         self.redis = None
-        
+
         # Add CORS middleware
         self.add_middleware(
             CORSMiddleware,
             allow_origins=["*"],
             allow_credentials=True,
             allow_methods=["*"],
-            allow_headers=["*"]
+            allow_headers=["*"],
         )
-        
+
         # Register routes
         self._register_routes()
-        
+
     async def initialize(self):
         """Initialize connections."""
         self.redis = await aioredis.from_url(self.redis_url)
-        
+
     async def cleanup(self):
         """Clean up resources."""
         if self.redis:
             await self.redis.close()
-            
+
     def _register_routes(self):
         """Register API routes."""
         # Code execution routes
@@ -91,125 +109,205 @@ class OpenHandsAPI(FastAPI, LoggerMixin):
             self.execute_code,
             methods=["POST"],
             response_model=Dict[str, Any],
-            dependencies=[Depends(self.verify_token)]
+            dependencies=[Depends(self.verify_token)],
         )
         self.add_api_route(
             "/executions/{execution_id}",
             self.get_execution,
             methods=["GET"],
             response_model=Dict[str, Any],
-            dependencies=[Depends(self.verify_token)]
+            dependencies=[Depends(self.verify_token)],
         )
-        
+
+        # Conversation routes
+        self.add_api_route(
+            "/conversations",
+            self.start_conversation,
+            methods=["POST"],
+            response_model=Dict[str, Any],
+            dependencies=[Depends(self.verify_token)],
+        )
+        self.add_api_route(
+            "/conversations",
+            self.list_conversations,
+            methods=["GET"],
+            response_model=List[str],
+            dependencies=[Depends(self.verify_token)],
+        )
+        self.add_api_route(
+            "/conversations/{conversation_id}/trajectory",
+            self.get_trajectory,
+            methods=["GET"],
+            response_model=Dict[str, Any],
+            dependencies=[Depends(self.verify_token)],
+        )
+        self.add_api_route(
+            "/conversations/{conversation_id}/list-files",
+            self.list_files,
+            methods=["GET"],
+            response_model=List[str],
+            dependencies=[Depends(self.verify_token)],
+        )
+        self.add_api_route(
+            "/conversations/{conversation_id}/select-file",
+            self.select_file,
+            methods=["GET"],
+            response_model=Dict[str, str],
+            dependencies=[Depends(self.verify_token)],
+        )
+
         # Docker routes
         self.add_api_route(
             "/docker/build",
             self.build_image,
             methods=["POST"],
             response_model=Dict[str, Any],
-            dependencies=[Depends(self.verify_token)]
+            dependencies=[Depends(self.verify_token)],
         )
         self.add_api_route(
             "/docker/run",
             self.run_container,
             methods=["POST"],
             response_model=Dict[str, Any],
-            dependencies=[Depends(self.verify_token)]
+            dependencies=[Depends(self.verify_token)],
         )
         self.add_api_route(
             "/docker/stop/{container_id}",
             self.stop_container,
             methods=["POST"],
             response_model=Dict[str, Any],
-            dependencies=[Depends(self.verify_token)]
+            dependencies=[Depends(self.verify_token)],
         )
         self.add_api_route(
             "/docker/logs/{container_id}",
             self.get_container_logs,
             methods=["GET"],
             response_model=str,
-            dependencies=[Depends(self.verify_token)]
+            dependencies=[Depends(self.verify_token)],
         )
-        
+
         # Docker Compose routes
         self.add_api_route(
             "/compose/deploy",
             self.deploy_stack,
             methods=["POST"],
             response_model=Dict[str, Any],
-            dependencies=[Depends(self.verify_token)]
+            dependencies=[Depends(self.verify_token)],
         )
         self.add_api_route(
             "/compose/stacks/{stack_name}",
             self.get_stack_status,
             methods=["GET"],
             response_model=Dict[str, Any],
-            dependencies=[Depends(self.verify_token)]
+            dependencies=[Depends(self.verify_token)],
         )
         self.add_api_route(
             "/compose/scale/{stack_name}",
             self.scale_service,
             methods=["POST"],
             response_model=Dict[str, Any],
-            dependencies=[Depends(self.verify_token)]
+            dependencies=[Depends(self.verify_token)],
         )
-        
+
         # System routes
         self.add_api_route(
             "/status",
             self.get_system_status,
             methods=["GET"],
-            response_model=Dict[str, Any]
+            response_model=Dict[str, Any],
         )
         self.add_api_route(
             "/languages",
             self.get_supported_languages,
             methods=["GET"],
-            response_model=List[str]
+            response_model=List[str],
         )
-        
-    async def verify_token(self,
-                          credentials: HTTPAuthorizationCredentials = Security(HTTPBearer())) -> bool:
+
+    async def verify_token(
+        self, credentials: HTTPAuthorizationCredentials = Security(HTTPBearer())
+    ) -> bool:
         """Verify JWT token.
-        
+
         Args:
             credentials: Bearer token credentials
-            
+
         Returns:
             bool: Whether token is valid
-            
+
         Raises:
             HTTPException: If token is invalid
         """
         try:
-            jwt.decode(
-                credentials.credentials,
-                self.secret_key,
-                algorithms=["HS256"]
-            )
+            jwt.decode(credentials.credentials, self.secret_key, algorithms=["HS256"])
             return True
         except jwt.InvalidTokenError:
-            raise HTTPException(
-                status_code=401,
-                detail="Invalid authentication token"
-            )
-            
+            raise HTTPException(status_code=401, detail="Invalid authentication token")
+
     @api_route(version="v1.0.0")
-    async def execute_code(self,
-                          execution: CodeExecution,
-                          background_tasks: BackgroundTasks) -> Dict[str, Any]:
+    async def start_conversation(self, conv: ConversationStart) -> Dict[str, Any]:
+        """Start a new conversation."""
+        conversation_id = (
+            f"conv_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}_{os.urandom(4).hex()}"
+        )
+        await self.redis.sadd("conversations", conversation_id)
+        await self.redis.rpush(
+            f"conversation:{conversation_id}:messages", conv.initial_user_msg
+        )
+        (self.conversations_dir / conversation_id).mkdir(exist_ok=True)
+        return {"status": "ok", "conversation_id": conversation_id}
+
+    @api_route(version="v1.0.0")
+    async def list_conversations(self) -> List[str]:
+        """List known conversations."""
+        convs = await self.redis.smembers("conversations")
+        return list(convs)
+
+    @api_route(version="v1.0.0")
+    async def get_trajectory(self, conversation_id: str) -> Dict[str, Any]:
+        """Get conversation trajectory."""
+        key = f"conversation:{conversation_id}:messages"
+        if not await self.redis.exists(key):
+            raise HTTPException(status_code=404, detail="Conversation not found")
+        messages = await self.redis.lrange(key, 0, -1)
+        return {"conversation_id": conversation_id, "trajectory": messages}
+
+    @api_route(version="v1.0.0")
+    async def list_files(self, conversation_id: str) -> List[str]:
+        """List files created by conversation."""
+        conv_dir = self.conversations_dir / conversation_id
+        if not conv_dir.is_dir():
+            raise HTTPException(status_code=404, detail="Conversation not found")
+        files = [str(p) for p in conv_dir.rglob("*") if p.is_file()]
+        return files
+
+    @api_route(version="v1.0.0")
+    async def select_file(self, conversation_id: str, file: str) -> Dict[str, str]:
+        """Return file contents."""
+        conv_dir = self.conversations_dir / conversation_id
+        target = (conv_dir / file).resolve()
+        if not str(target).startswith(str(conv_dir)) or not target.is_file():
+            raise HTTPException(status_code=404, detail="File not found")
+        content = target.read_text()
+        return {"code": content}
+
+    @api_route(version="v1.0.0")
+    async def execute_code(
+        self, execution: CodeExecution, background_tasks: BackgroundTasks
+    ) -> Dict[str, Any]:
         """Execute code in isolated container.
-        
+
         Args:
             execution: Code execution details
             background_tasks: Background tasks runner
-            
+
         Returns:
             Dict[str, Any]: Execution details
         """
         # Generate execution ID
-        execution_id = f"exec_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{os.urandom(4).hex()}"
-        
+        execution_id = (
+            f"exec_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{os.urandom(4).hex()}"
+        )
+
         # Store execution details
         await self.redis.hset(
             f"execution:{execution_id}",
@@ -219,167 +317,144 @@ class OpenHandsAPI(FastAPI, LoggerMixin):
                 "language": execution.language,
                 "task_description": execution.task_description,
                 "requirements": ",".join(execution.requirements),
-                "created_at": datetime.now().isoformat()
-            }
+                "created_at": datetime.now().isoformat(),
+            },
         )
-        
+
         # Add to execution queue
-        background_tasks.add_task(
-            self._execute_code_task,
-            execution_id,
-            execution
-        )
-        
-        return {
-            "execution_id": execution_id,
-            "status": "pending"
-        }
-        
+        background_tasks.add_task(self._execute_code_task, execution_id, execution)
+
+        return {"execution_id": execution_id, "status": "pending"}
+
     async def _execute_code_task(self, execution_id: str, execution: CodeExecution):
         """Execute code in background.
-        
+
         Args:
             execution_id: Execution ID
             execution: Code execution details
         """
         try:
             # Update status
-            await self.redis.hset(
-                f"execution:{execution_id}",
-                "status",
-                "running"
-            )
-            
+            await self.redis.hset(f"execution:{execution_id}", "status", "running")
+
             # Create container config
             container_config = {
                 "image": f"openhands/{execution.language}:latest",
                 "command": ["python", "-c", execution.code],
-                "environment": {
-                    "PYTHONUNBUFFERED": "1"
-                },
+                "environment": {"PYTHONUNBUFFERED": "1"},
                 "mem_limit": "512m",
                 "cpu_quota": 100000,  # 10% of CPU
-                "network_disabled": True
+                "network_disabled": True,
             }
-            
+
             # Run container
-            container = self.docker.containers.run(
-                **container_config,
-                detach=True
-            )
-            
+            container = self.docker.containers.run(**container_config, detach=True)
+
             try:
                 # Wait for container
                 result = container.wait(timeout=30)
-                
+
                 # Get logs
                 logs = container.logs().decode()
-                
+
                 # Store results
                 await self.redis.hset(
                     f"execution:{execution_id}",
                     mapping={
-                        "status": "completed" if result["StatusCode"] == 0 else "failed",
+                        "status": (
+                            "completed" if result["StatusCode"] == 0 else "failed"
+                        ),
                         "exit_code": result["StatusCode"],
                         "output": logs,
-                        "completed_at": datetime.now().isoformat()
-                    }
+                        "completed_at": datetime.now().isoformat(),
+                    },
                 )
-                
+
             finally:
                 # Cleanup container
                 container.remove(force=True)
-                
+
         except Exception as e:
             # Log error
-            self.log_error(e, {
-                "execution_id": execution_id,
-                "language": execution.language
-            })
-            
+            self.log_error(
+                e, {"execution_id": execution_id, "language": execution.language}
+            )
+
             # Update status
             await self.redis.hset(
                 f"execution:{execution_id}",
                 mapping={
                     "status": "error",
                     "error": str(e),
-                    "completed_at": datetime.now().isoformat()
-                }
+                    "completed_at": datetime.now().isoformat(),
+                },
             )
-            
+
     @api_route(version="v1.0.0")
     async def get_execution(self, execution_id: str) -> Dict[str, Any]:
         """Get execution details.
-        
+
         Args:
             execution_id: Execution ID
-            
+
         Returns:
             Dict[str, Any]: Execution details
-            
+
         Raises:
             HTTPException: If execution not found
         """
         # Get execution details
         execution = await self.redis.hgetall(f"execution:{execution_id}")
-        
+
         if not execution:
             raise HTTPException(
-                status_code=404,
-                detail=f"Execution {execution_id} not found"
+                status_code=404, detail=f"Execution {execution_id} not found"
             )
-            
-        return {
-            "execution_id": execution_id,
-            **execution
-        }
-        
+
+        return {"execution_id": execution_id, **execution}
+
     @api_route(version="v1.0.0")
     async def build_image(self, build: DockerBuild) -> Dict[str, Any]:
         """Build Docker image.
-        
+
         Args:
             build: Build details
-            
+
         Returns:
             Dict[str, Any]: Build results
         """
         try:
             # Create build context
             context = {
-                name: content.encode()
-                for name, content in build.context.items()
+                name: content.encode() for name, content in build.context.items()
             }
-            
+
             # Build image
             image, logs = self.docker.images.build(
                 fileobj=build.dockerfile.encode(),
                 tag=build.tag,
                 rm=True,
                 forcerm=True,
-                buildargs=context
+                buildargs=context,
             )
-            
+
             return {
                 "image_id": image.id,
                 "tag": build.tag,
-                "logs": [log.get("stream", "") for log in logs]
+                "logs": [log.get("stream", "") for log in logs],
             }
-            
+
         except Exception as e:
             self.log_error(e, {"tag": build.tag})
-            raise HTTPException(
-                status_code=500,
-                detail=str(e)
-            )
-            
+            raise HTTPException(status_code=500, detail=str(e))
+
     @api_route(version="v1.0.0")
     async def run_container(self, config: DockerRun) -> Dict[str, Any]:
         """Run Docker container.
-        
+
         Args:
             config: Container configuration
-            
+
         Returns:
             Dict[str, Any]: Container details
         """
@@ -391,75 +466,60 @@ class OpenHandsAPI(FastAPI, LoggerMixin):
                 environment=config.environment,
                 ports=config.ports,
                 volumes=config.volumes,
-                detach=True
+                detach=True,
             )
-            
-            return {
-                "container_id": container.id,
-                "status": container.status
-            }
-            
+
+            return {"container_id": container.id, "status": container.status}
+
         except Exception as e:
             self.log_error(e, {"image": config.image})
-            raise HTTPException(
-                status_code=500,
-                detail=str(e)
-            )
-            
+            raise HTTPException(status_code=500, detail=str(e))
+
     @api_route(version="v1.0.0")
     async def stop_container(self, container_id: str) -> Dict[str, Any]:
         """Stop Docker container.
-        
+
         Args:
             container_id: Container ID
-            
+
         Returns:
             Dict[str, Any]: Operation result
         """
         try:
             container = self.docker.containers.get(container_id)
             container.stop()
-            
-            return {
-                "container_id": container_id,
-                "status": "stopped"
-            }
-            
+
+            return {"container_id": container_id, "status": "stopped"}
+
         except Exception as e:
             self.log_error(e, {"container_id": container_id})
-            raise HTTPException(
-                status_code=500,
-                detail=str(e)
-            )
-            
+            raise HTTPException(status_code=500, detail=str(e))
+
     @api_route(version="v1.0.0")
     async def get_container_logs(self, container_id: str) -> str:
         """Get container logs.
-        
+
         Args:
             container_id: Container ID
-            
+
         Returns:
             str: Container logs
         """
         try:
             container = self.docker.containers.get(container_id)
             return container.logs().decode()
-            
+
         except Exception as e:
             self.log_error(e, {"container_id": container_id})
-            raise HTTPException(
-                status_code=500,
-                detail=str(e)
-            )
-            
+            raise HTTPException(status_code=500, detail=str(e))
+
     @api_route(version="v1.0.0")
     async def deploy_stack(self, deployment: ComposeDeployment) -> Dict[str, Any]:
         """Deploy Docker Compose stack.
-        
+
         Args:
             deployment: Stack deployment details
-            
+
         Returns:
             Dict[str, Any]: Deployment results
         """
@@ -468,100 +528,78 @@ class OpenHandsAPI(FastAPI, LoggerMixin):
             compose_path = f"/tmp/{deployment.stack_name}_compose.yml"
             with open(compose_path, "w") as f:
                 f.write(deployment.compose_file)
-                
+
             # Deploy stack
             self.docker.compose.up(
                 project_name=deployment.stack_name,
                 compose_files=[compose_path],
                 environment=deployment.environment,
-                detach=True
+                detach=True,
             )
-            
-            return {
-                "stack_name": deployment.stack_name,
-                "status": "deployed"
-            }
-            
+
+            return {"stack_name": deployment.stack_name, "status": "deployed"}
+
         except Exception as e:
             self.log_error(e, {"stack_name": deployment.stack_name})
-            raise HTTPException(
-                status_code=500,
-                detail=str(e)
-            )
-            
+            raise HTTPException(status_code=500, detail=str(e))
+
     @api_route(version="v1.0.0")
     async def get_stack_status(self, stack_name: str) -> Dict[str, Any]:
         """Get stack status.
-        
+
         Args:
             stack_name: Stack name
-            
+
         Returns:
             Dict[str, Any]: Stack status
         """
         try:
-            services = self.docker.compose.ps(
-                project_name=stack_name,
-                services=True
-            )
-            
+            services = self.docker.compose.ps(project_name=stack_name, services=True)
+
             return {
                 "stack_name": stack_name,
                 "services": {
-                    service.name: {
-                        "state": service.state,
-                        "status": service.status
-                    }
+                    service.name: {"state": service.state, "status": service.status}
                     for service in services
-                }
+                },
             }
-            
+
         except Exception as e:
             self.log_error(e, {"stack_name": stack_name})
-            raise HTTPException(
-                status_code=500,
-                detail=str(e)
-            )
-            
+            raise HTTPException(status_code=500, detail=str(e))
+
     @api_route(version="v1.0.0")
-    async def scale_service(self,
-                          stack_name: str,
-                          scale: ServiceScale) -> Dict[str, Any]:
+    async def scale_service(
+        self, stack_name: str, scale: ServiceScale
+    ) -> Dict[str, Any]:
         """Scale stack service.
-        
+
         Args:
             stack_name: Stack name
             scale: Scaling configuration
-            
+
         Returns:
             Dict[str, Any]: Operation result
         """
         try:
             self.docker.compose.scale(
-                project_name=stack_name,
-                service_scale={scale.service: scale.replicas}
+                project_name=stack_name, service_scale={scale.service: scale.replicas}
             )
-            
+
             return {
                 "stack_name": stack_name,
                 "service": scale.service,
-                "replicas": scale.replicas
+                "replicas": scale.replicas,
             }
-            
+
         except Exception as e:
-            self.log_error(e, {
-                "stack_name": stack_name,
-                "service": scale.service
-            })
-            raise HTTPException(
-                status_code=500,
-                detail=str(e)
-            )
-            
+            self.log_error(e, {"stack_name": stack_name, "service": scale.service})
+            raise HTTPException(status_code=500, detail=str(e))
+
     @api_route(version="v1.0.0")
     async def get_system_status(self) -> Dict[str, Any]:
         """Get system status.
-        
+
         Returns:
             Dict[str, Any]: System status
         """
@@ -569,43 +607,35 @@ class OpenHandsAPI(FastAPI, LoggerMixin):
             return {
                 "docker": {
                     "version": self.docker.version(),
-                    "info": self.docker.info()
+                    "info": self.docker.info(),
                 },
                 "redis": {
                     "connected": bool(self.redis),
-                    "info": await self.redis.info() if self.redis else None
-                }
+                    "info": await self.redis.info() if self.redis else None,
+                },
             }
-            
+
         except Exception as e:
             self.log_error(e, {})
-            raise HTTPException(
-                status_code=500,
-                detail=str(e)
-            )
-            
+            raise HTTPException(status_code=500, detail=str(e))
+
     @api_route(version="v1.0.0")
     async def get_supported_languages(self) -> List[str]:
         """Get supported programming languages.
-        
+
         Returns:
             List[str]: Supported languages
         """
         try:
             # Get language images
-            images = self.docker.images.list(
-                filters={"reference": "openhands/*"}
-            )
-            
+            images = self.docker.images.list(filters={"reference": "openhands/*"})
+
             return [
                 image.tags[0].split("/")[1].split(":")[0]
                 for image in images
                 if image.tags
             ]
-            
+
         except Exception as e:
             self.log_error(e, {})
-            raise HTTPException(
-                status_code=500,
-                detail=str(e)
-            )
+            raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_openhands_agents.py
+++ b/tests/test_openhands_agents.py
@@ -1,67 +1,107 @@
 import unittest
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, AsyncMock
 import asyncio
+import sys
+import types
+
+module_mlflow = types.ModuleType("mlflow")
+setattr(module_mlflow, "active_run", lambda: None)
+setattr(module_mlflow, "start_run", lambda *a, **kw: None)
+setattr(module_mlflow, "end_run", lambda: None)
+sys.modules.setdefault("mlflow", module_mlflow)
+sys.modules.setdefault("torch", types.ModuleType("torch"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+sys.modules.setdefault("langchain", types.ModuleType("langchain"))
+module_schema = types.ModuleType("langchain.schema")
+setattr(module_schema, "Document", object)
+sys.modules.setdefault("langchain.schema", module_schema)
+module_chains = types.ModuleType("langchain.chains")
+setattr(module_chains, "RetrievalQA", object)
+sys.modules.setdefault("langchain.chains", module_chains)
+module_prompts = types.ModuleType("langchain.prompts")
+setattr(module_prompts, "PromptTemplate", object)
+sys.modules.setdefault("langchain.prompts", module_prompts)
+sys.modules.setdefault("langchain_core", types.ModuleType("langchain_core"))
+module_core_runnables = types.ModuleType("langchain_core.runnables")
+setattr(module_core_runnables, "RunnablePassthrough", object)
+sys.modules.setdefault("langchain_core.runnables", module_core_runnables)
+module_core_llms = types.ModuleType("langchain_core.language_models.llms")
+setattr(module_core_llms, "BaseLLM", object)
+sys.modules.setdefault("langchain_core.language_models.llms", module_core_llms)
+module_core_callbacks = types.ModuleType("langchain_core.callbacks.manager")
+setattr(module_core_callbacks, "CallbackManagerForLLMRun", object)
+sys.modules.setdefault(
+    "langchain_core.callbacks.manager",
+    module_core_callbacks,
+)
+sys.modules.setdefault("langchain_openai", types.ModuleType("langchain_openai"))
+module_openai = sys.modules["langchain_openai"]
+setattr(module_openai, "OpenAI", object)
+setattr(module_openai, "ChatOpenAI", object)
+setattr(module_openai, "OpenAIEmbeddings", object)
+sys.modules.setdefault("langchain_core.outputs", types.ModuleType("lc_out"))
+setattr(sys.modules["langchain_core.outputs"], "LLMResult", object)
+setattr(sys.modules["langchain_core.outputs"], "Generation", object)
+
 from agents.openhands.base_openhands_agent import OpenHandsAgent
 from agents.openhands.docker_agent import DockerAgent
 from agents.openhands.compose_agent import DockerComposeAgent
+
 
 class TestOpenHandsAgent(unittest.TestCase):
     def setUp(self):
         """Set up test environment."""
         # Mock MLflow
-        self.mlflow_patcher = patch('utils.logging_util.mlflow')
+        self.mlflow_patcher = patch("utils.logging_util.mlflow")
         self.mock_mlflow = self.mlflow_patcher.start()
-        
+
         # Mock aiohttp session
-        self.session_patcher = patch('aiohttp.ClientSession')
+        self.session_patcher = patch("aiohttp.ClientSession")
         self.mock_session = self.session_patcher.start()
-        
+
         # Set up mock session instance
         self.mock_session_instance = AsyncMock()
         self.mock_session.return_value = self.mock_session_instance
-        
+
         # Set up mock response
         self.mock_response = AsyncMock()
         self.mock_response.status = 200
         self.mock_response.json = AsyncMock(return_value={"status": "success"})
         self.mock_response.text = AsyncMock(return_value="success")
-        
+
         # Initialize agent
-        self.agent = OpenHandsAgent(
-            name="test_agent",
-            github_token="test_token"
-        )
-        
+        self.agent = OpenHandsAgent(name="test_agent", github_token="test_token")
+
     def tearDown(self):
         """Clean up after tests."""
         self.mlflow_patcher.stop()
         self.session_patcher.stop()
-        
+
     async def test_submit_code(self):
         """Test code submission."""
         # Mock response
-        self.mock_session_instance.post.return_value.__aenter__.return_value = self.mock_response
-        
+        self.mock_session_instance.post.return_value.__aenter__.return_value = (
+            self.mock_response
+        )
+
         # Submit code
         result = await self.agent.submit_code(
-            code="print('test')",
-            language="python",
-            task_description="Test task"
+            code="print('test')", language="python", task_description="Test task"
         )
-        
+
         # Check result
         self.assertEqual(result["status"], "success")
-        
+
         # Verify API call
         self.mock_session_instance.post.assert_called_once()
-        
+
     async def test_wait_for_execution(self):
         """Test execution waiting."""
         # Mock responses
         responses = [
             {"status": "running"},
             {"status": "running"},
-            {"status": "completed"}
+            {"status": "completed"},
         ]
         mock_responses = []
         for resp in responses:
@@ -69,154 +109,193 @@ class TestOpenHandsAgent(unittest.TestCase):
             mock_response.status = 200
             mock_response.json = AsyncMock(return_value=resp)
             mock_responses.append(mock_response)
-            
-        self.mock_session_instance.get.return_value.__aenter__.side_effect = mock_responses
-        
-        # Wait for execution
-        result = await self.agent.wait_for_execution(
-            "test_id",
-            poll_interval=0.1
+
+        self.mock_session_instance.get.return_value.__aenter__.side_effect = (
+            mock_responses
         )
-        
+
+        # Wait for execution
+        result = await self.agent.wait_for_execution("test_id", poll_interval=0.1)
+
         # Check result
         self.assertEqual(result["status"], "completed")
-        
+
         # Verify API calls
         self.assertEqual(self.mock_session_instance.get.call_count, 3)
+
 
 class TestDockerAgent(unittest.TestCase):
     def setUp(self):
         """Set up test environment."""
         # Mock MLflow
-        self.mlflow_patcher = patch('utils.logging_util.mlflow')
+        self.mlflow_patcher = patch("utils.logging_util.mlflow")
         self.mock_mlflow = self.mlflow_patcher.start()
-        
+
         # Mock aiohttp session
-        self.session_patcher = patch('aiohttp.ClientSession')
+        self.session_patcher = patch("aiohttp.ClientSession")
         self.mock_session = self.session_patcher.start()
-        
+
         # Set up mock session instance
         self.mock_session_instance = AsyncMock()
         self.mock_session.return_value = self.mock_session_instance
-        
+
         # Set up mock response
         self.mock_response = AsyncMock()
         self.mock_response.status = 200
         self.mock_response.json = AsyncMock(return_value={"status": "success"})
-        
+
         # Initialize agent
-        self.agent = DockerAgent(
-            name="test_docker",
-            github_token="test_token"
-        )
-        
+        self.agent = DockerAgent(name="test_docker", github_token="test_token")
+
     def tearDown(self):
         """Clean up after tests."""
         self.mlflow_patcher.stop()
         self.session_patcher.stop()
-        
+
     async def test_build_image(self):
         """Test Docker image building."""
         # Mock response
-        self.mock_session_instance.post.return_value.__aenter__.return_value = self.mock_response
-        
+        self.mock_session_instance.post.return_value.__aenter__.return_value = (
+            self.mock_response
+        )
+
         # Build image
         result = await self.agent.build_image(
             dockerfile="FROM python:3.9",
             context={"requirements.txt": "requests==2.26.0"},
-            tag="test:latest"
+            tag="test:latest",
         )
-        
+
         # Check result
         self.assertEqual(result["status"], "success")
-        
+
         # Verify API call
         self.mock_session_instance.post.assert_called_once()
-        
+
     async def test_run_container(self):
         """Test container running."""
         # Mock response
-        self.mock_session_instance.post.return_value.__aenter__.return_value = self.mock_response
-        
+        self.mock_session_instance.post.return_value.__aenter__.return_value = (
+            self.mock_response
+        )
+
         # Run container
         result = await self.agent.run_container(
-            image="test:latest",
-            command="python app.py",
-            environment={"DEBUG": "1"}
+            image="test:latest", command="python app.py", environment={"DEBUG": "1"}
         )
-        
+
         # Check result
         self.assertEqual(result["status"], "success")
-        
+
         # Verify API call
         self.mock_session_instance.post.assert_called_once()
+
 
 class TestDockerComposeAgent(unittest.TestCase):
     def setUp(self):
         """Set up test environment."""
         # Mock MLflow
-        self.mlflow_patcher = patch('utils.logging_util.mlflow')
+        self.mlflow_patcher = patch("utils.logging_util.mlflow")
         self.mock_mlflow = self.mlflow_patcher.start()
-        
+
         # Mock aiohttp session
-        self.session_patcher = patch('aiohttp.ClientSession')
+        self.session_patcher = patch("aiohttp.ClientSession")
         self.mock_session = self.session_patcher.start()
-        
+
         # Set up mock session instance
         self.mock_session_instance = AsyncMock()
         self.mock_session.return_value = self.mock_session_instance
-        
+
         # Set up mock response
         self.mock_response = AsyncMock()
         self.mock_response.status = 200
         self.mock_response.json = AsyncMock(return_value={"status": "success"})
-        
+
         # Initialize agent
-        self.agent = DockerComposeAgent(
-            name="test_compose",
-            github_token="test_token"
-        )
-        
+        self.agent = DockerComposeAgent(name="test_compose", github_token="test_token")
+
     def tearDown(self):
         """Clean up after tests."""
         self.mlflow_patcher.stop()
         self.session_patcher.stop()
-        
+
     async def test_deploy_stack(self):
         """Test stack deployment."""
         # Mock response
-        self.mock_session_instance.post.return_value.__aenter__.return_value = self.mock_response
-        
+        self.mock_session_instance.post.return_value.__aenter__.return_value = (
+            self.mock_response
+        )
+
         # Deploy stack
         result = await self.agent.deploy_stack(
             compose_file="version: '3'\\nservices:\\n  web:\\n    image: nginx",
             stack_name="test_stack",
-            environment={"DEBUG": "1"}
+            environment={"DEBUG": "1"},
         )
-        
+
         # Check result
         self.assertEqual(result["status"], "success")
-        
-        # Verify API call
-        self.mock_session_instance.post.assert_called_once()
-        
-    async def test_scale_service(self):
-        """Test service scaling."""
-        # Mock response
-        self.mock_session_instance.post.return_value.__aenter__.return_value = self.mock_response
-        
-        # Scale service
-        result = await self.agent.scale_service(
-            stack_name="test_stack",
-            service="web",
-            replicas=3
-        )
-        
-        # Check result
-        self.assertEqual(result["status"], "success")
-        
+
         # Verify API call
         self.mock_session_instance.post.assert_called_once()
 
-if __name__ == '__main__':
+    async def test_scale_service(self):
+        """Test service scaling."""
+        # Mock response
+        self.mock_session_instance.post.return_value.__aenter__.return_value = (
+            self.mock_response
+        )
+
+        # Scale service
+        result = await self.agent.scale_service(
+            stack_name="test_stack", service="web", replicas=3
+        )
+
+        # Check result
+        self.assertEqual(result["status"], "success")
+
+        # Verify API call
+        self.mock_session_instance.post.assert_called_once()
+
+
+class TestConversationEndpoints(unittest.TestCase):
+    def setUp(self):
+        self.mlflow_patcher = patch("utils.logging_util.mlflow")
+        self.mlflow_patcher.start()
+        self.session_patcher = patch("aiohttp.ClientSession")
+        self.mock_session = self.session_patcher.start()
+
+        self.mock_session_instance = AsyncMock()
+        self.mock_session.return_value = self.mock_session_instance
+
+        self.mock_response = AsyncMock()
+        self.mock_response.status = 200
+        self.mock_response.json = AsyncMock(return_value={"conversation_id": "c1"})
+        self.mock_response.text = AsyncMock(return_value="ok")
+
+        self.agent = OpenHandsAgent(name="conv_agent", github_token="token")
+
+    def tearDown(self):
+        self.mlflow_patcher.stop()
+        self.session_patcher.stop()
+
+    async def test_start_conversation(self):
+        self.mock_session_instance.post.return_value.__aenter__.return_value = (
+            self.mock_response
+        )
+        result = await self.agent.start_conversation("hello")
+        self.assertEqual(result["conversation_id"], "c1")
+        self.mock_session_instance.post.assert_called_once()
+
+    async def test_get_trajectory(self):
+        self.mock_response.json = AsyncMock(return_value={"trajectory": ["hi"]})
+        self.mock_session_instance.get.return_value.__aenter__.return_value = (
+            self.mock_response
+        )
+        result = await self.agent.get_trajectory("c1")
+        self.assertEqual(result["trajectory"], ["hi"])
+        self.mock_session_instance.get.assert_called_once()
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend OpenHands API server with conversation endpoints
- add matching helper methods to OpenHandsAgent
- stub external deps in tests and add conversation tests

## Testing
- `ruff check agents/openhands/base_openhands_agent.py openhands_api/server.py tests/test_openhands_agents.py`
- `black agents/openhands/base_openhands_agent.py openhands_api/server.py tests/test_openhands_agents.py`
- `pytest tests/test_openhands_agents.py tests/test_worker_openhands.py -q` *(fails: ModuleNotFoundError: No module named 'langchain.text_splitter')*

------
https://chatgpt.com/codex/tasks/task_e_68654f8979748324882811b0c60c360d