### PR TITLE
Update docs to release 1.0.3

### DIFF
--- a/.codex.json
+++ b/.codex.json
@@ -2,7 +2,7 @@
     "project": "Agent-NN MCP Modernization",
     "objective": "Schrittweise Umstellung auf eine Modular Control Plane Architektur",
     "model": "gpt-4",
-    "version": "1.0.1",
+    "version": "1.0.3",
     "approvalMode": "full-auto",
     "fullAutoErrorMode": "ignore-and-continue",
     "notify": false,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,11 @@ Sessions und Vektordaten bei Neustarts erhalten bleiben.
 - Deployment-Skripte und Dokumentation für Version 1.0.0 erstellt
 ### Fortschritt Phase 4.3
 - Betriebsmetriken, Audit-Logs und produktive Umgebungsdateien hinzugefügt
+### Fortschritt Phase 4.4
+- Flowise-Export stabilisiert und Release 1.0.3 erstellt
+### Fortschritt Phase 4.6
+- Lokaler Installationsworkflow mit `poetry install --no-root` dokumentiert
 ## Allgemeine Projekt-Richtlinien
-
 Unabhängig von der Rolle gelten folgende übergreifende Regeln für den Codex-Agenten, um qualitativ hochwertige Beiträge zu gewährleisten:
 
 - **Kenntnis der Codebase:** Der Agent soll vorhandenen Code wiederverwenden und verstehen, statt duplizieren. Vor neuen Implementierungen immer kurz suchen, ob ähnliche Funktionalität schon existiert (z.B. Utility-Funktionen, Basisklassen).  

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ![Build](https://img.shields.io/badge/build-passing-brightgreen)
 
 Agent-NN ist ein Multi-Agent-System mit integrierten neuronalen Netzen. Jeder Service erfüllt eine klar definierte Aufgabe und kommuniziert über REST-Schnittstellen. Neben den Backend-Diensten stellt das Projekt ein Python‑SDK, eine CLI und ein React-basiertes Frontend bereit. Weitere Dokumentation befindet sich im Ordner [docs/](docs/).
+Aktuelle Version: **v1.0.3** – Flowise-Export und Dokumentation aktualisiert.
 
 ## Systemvoraussetzungen
 
@@ -12,8 +13,8 @@ Agent-NN ist ein Multi-Agent-System mit integrierten neuronalen Netzen. Jeder Se
 
 ```mermaid
 graph TD
-    U[User/CLI] --> G[API-Gateway]
-    G --> D[Task-Dispatcher]
+    U[User/Web UI] --> G[API-Gateway]
+    G --> D[Task Dispatcher]
     D --> R[Agent Registry]
     D --> S[Session Manager]
     D --> W[Worker Services]
@@ -21,6 +22,8 @@ graph TD
     D --> L[LLM Gateway]
     W --> V
     W --> L
+    D --> M[Monitoring]
+    W --> M
 ```
 
 - **Task-Dispatcher** – Koordiniert eingehende Aufgaben.
@@ -28,6 +31,7 @@ graph TD
 - **Session Manager** – Speichert Kontexte in Redis.
 - **Vector Store** – Bietet Dokumentensuche für RAG.
 - **LLM Gateway** – Einheitliche Schnittstelle zu Sprachmodellen.
+- **Monitoring** – Prometheus sammelt Metriken aller Dienste.
 - **Worker Services** – Domänenspezifische Agenten.
 
 ## Schnellstart

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
-# Release Notes v1.0.2
+# Release Notes v1.0.3
 
-Stabiles Release der Flowise‑Integration. Quickstart und Troubleshooting sind aktualisiert, Fehlerbehandlung sowie Authentifizierung getestet. Bekannte Limitierungen der Testumgebung sind dokumentiert. Details siehe [docs/integrations/flowise.md](integrations/flowise.md) und den [Changelog](../CHANGELOG.md).
+Dieses Release finalisiert die Flowise-Export-Funktion und erweitert die Dokumentation.
+Fehlercodes sind vereinheitlicht und die Monitoring-Konfiguration wurde verbessert.
+Details siehe [CHANGELOG](../CHANGELOG.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 # Agent-NN Documentation
 
 Welcome to the Agent-NN documentation! This documentation will help you understand and use our multi-agent system with neural network-based task routing.
+Current stable version: **v1.0.3**.
 
 ## Overview
 

--- a/docs/integrations/flowise.md
+++ b/docs/integrations/flowise.md
@@ -1,6 +1,6 @@
 # FlowiseAI Integration
 
-[FlowiseAI](https://flowiseai.com/) bietet eine grafische Oberfläche zum Erstellen von Chatbot‑Flows. Agent‑NN lässt sich sowohl als Quelle für Antworten als auch als externer Aufrufer nutzen. Mit Version **v1.0.2** gilt die Flowise‑Integration als stabil.
+[FlowiseAI](https://flowiseai.com/) bietet eine grafische Oberfläche zum Erstellen von Chatbot‑Flows. Agent‑NN lässt sich sowohl als Quelle für Antworten als auch als externer Aufrufer nutzen. Mit Version **v1.0.3** gilt die Flowise‑Integration als stabil.
 
 ## Agent‑NN als Flowise Komponente
 

--- a/docs/releases/v1.0.3.md
+++ b/docs/releases/v1.0.3.md
@@ -1,0 +1,5 @@
+# v1.0.3 Stable Release
+
+- Flowise-Export über `GET /agents/{id}?format=flowise` finalisiert
+- Fehlercodes konsolidiert und Dokumentation erweitert
+- Monitoring-Beispiele für Prometheus ergänzt


### PR DESCRIPTION
## Summary
- mention current version and update architecture diagram in README
- add release notes for v1.0.3
- bump Flowise integration docs
- note stable version in docs index
- extend AGENTS progress
- set codex version to 1.0.3

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*
- `ruff .` *(fails: unrecognized subcommand)*
- `mypy .` *(fails: many missing stubs)*

------
https://chatgpt.com/codex/tasks/task_e_686558cde3308324b4c8ddd1a3603665