### PR TITLE
Implement reinforcement learner and federation manager

### DIFF
--- a/docs/architecture/federation.md
+++ b/docs/architecture/federation.md
@@ -1,0 +1,13 @@
+# Federation Manager
+
+The Federation Manager coordinates tasks across multiple Agent-NN clusters. Nodes
+can be registered via the API and tasks are forwarded to the selected cluster.
+
+```mermaid
+graph TD
+    APP[Local Dispatcher] --> FED[Federation Manager]
+    FED --> NODE1[Remote Agent-NN]
+    FED --> NODE2[Remote Agent-NN]
+```
+
+Use `/nodes` to register a remote instance and `/dispatch/{name}` to send tasks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
     - Worker Agents: components/worker-agents.md
     - Neural Models: components/neural-models.md
     - Vector Store: components/vector-store.md
+    - Federation Manager: architecture/federation.md
   - Advanced Features:
     - Security: advanced/security.md
     - Evaluation: advanced/evaluation.md

--- a/services/federation_manager/config.py
+++ b/services/federation_manager/config.py
@@ -1,0 +1,11 @@
+"""Configuration for the Federation Manager service."""
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    host: str = "0.0.0.0"
+    port: int = 8015
+
+
+settings = Settings()

--- a/services/federation_manager/main.py
+++ b/services/federation_manager/main.py
@@ -1,0 +1,31 @@
+"""FastAPI entrypoint for the Federation Manager service."""
+
+from fastapi import FastAPI
+
+from core.run_service import run_service
+from core.logging_utils import LoggingMiddleware, exception_handler, init_logging
+from core.metrics_utils import MetricsMiddleware, metrics_router
+from core.auth_utils import AuthMiddleware
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
+
+from ..health_router import health_router
+from .config import settings
+from .routes import router as fed_router
+
+logger = init_logging("federation_manager")
+app = FastAPI(title="Federation Manager Service")
+app.add_middleware(LoggingMiddleware, logger=logger)
+app.add_middleware(AuthMiddleware, logger=logger)
+app.add_middleware(MetricsMiddleware, service="federation_manager")
+app.add_exception_handler(Exception, exception_handler(logger))
+limiter = Limiter(key_func=get_remote_address)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.include_router(metrics_router())
+app.include_router(health_router)
+app.include_router(fed_router)
+
+if __name__ == "__main__":
+    run_service(app, host=settings.host, port=settings.port)

--- a/services/federation_manager/routes.py
+++ b/services/federation_manager/routes.py
@@ -1,0 +1,30 @@
+"""API routes for the Federation Manager service."""
+
+from fastapi import APIRouter
+
+from utils.api_utils import api_route
+from core.model_context import ModelContext
+from .service import FederationManagerService
+
+router = APIRouter()
+service = FederationManagerService()
+
+
+@api_route(version="v1.0.0")
+@router.post("/nodes")
+async def register(name: str, base_url: str) -> dict:
+    service.register_node(name, base_url)
+    return {"status": "ok"}
+
+
+@api_route(version="v1.0.0")
+@router.delete("/nodes/{name}")
+async def remove(name: str) -> dict:
+    service.remove_node(name)
+    return {"status": "ok"}
+
+
+@api_route(version="v1.0.0")
+@router.post("/dispatch/{name}", response_model=ModelContext)
+async def dispatch(name: str, ctx: ModelContext) -> ModelContext:
+    return service.dispatch(name, ctx)

--- a/services/federation_manager/service.py
+++ b/services/federation_manager/service.py
@@ -1,0 +1,44 @@
+"""Manage federated Agent-NN nodes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import httpx
+
+from core.model_context import ModelContext
+
+
+@dataclass
+class FederatedNode:
+    """Information about a remote Agent-NN instance."""
+
+    name: str
+    base_url: str
+
+
+class FederationManagerService:
+    """Register and dispatch tasks to federated nodes."""
+
+    def __init__(self) -> None:
+        self.nodes: Dict[str, FederatedNode] = {}
+
+    def register_node(self, name: str, base_url: str) -> None:
+        self.nodes[name] = FederatedNode(name, base_url.rstrip("/"))
+
+    def remove_node(self, name: str) -> None:
+        self.nodes.pop(name, None)
+
+    def dispatch(self, node_name: str, ctx: ModelContext) -> ModelContext:
+        node = self.nodes.get(node_name)
+        if not node:
+            raise ValueError(f"node {node_name} not registered")
+        with httpx.Client() as client:
+            resp = client.post(
+                f"{node.base_url}/dispatch",
+                json=ctx.model_dump(),
+                timeout=10,
+            )
+            resp.raise_for_status()
+            return ModelContext(**resp.json())

--- a/tests/training/test_reinforcement_learning.py
+++ b/tests/training/test_reinforcement_learning.py
@@ -1,0 +1,18 @@
+from training.reinforcement_learning import QTableLearner
+from core.model_context import TaskContext
+
+
+def test_qtable_learning_updates_values():
+    learner = QTableLearner(learning_rate=1.0, epsilon=0.0)
+    task = TaskContext(task_type="docker")
+    learner.learn(task, "agent-a", reward=1.0)
+    assert learner.table[("docker", "agent-a")] == 1.0
+
+
+def test_qtable_select_agent_returns_best():
+    learner = QTableLearner(epsilon=0.0)
+    task = TaskContext(task_type="docker")
+    learner.table[("docker", "a1")] = 0.2
+    learner.table[("docker", "a2")] = 0.8
+    agent = learner.select_agent(task, ["a1", "a2"])
+    assert agent == "a2"

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,11 +1,22 @@
-"""Training package for agent selector model."""
-from .data_logger import InteractionLogger, AgentInteractionDataset, create_dataloaders
-from .agent_selector_model import AgentSelectorModel, AgentSelectorTrainer
+"""Training utilities."""
 
-__all__ = [
-    'InteractionLogger',
-    'AgentInteractionDataset',
-    'create_dataloaders',
-    'AgentSelectorModel',
-    'AgentSelectorTrainer'
-]
+# Optional imports may pull in heavy dependencies. Wrap them in try/except so
+# lightweight modules like :mod:`reinforcement_learning` can be used without
+# requiring packages such as pandas or torch during import.
+try:  # pragma: no cover - optional dependencies
+    from .data_logger import (
+        InteractionLogger,
+        AgentInteractionDataset,
+        create_dataloaders,
+    )
+    from .agent_selector_model import AgentSelectorModel, AgentSelectorTrainer
+
+    __all__ = [
+        "InteractionLogger",
+        "AgentInteractionDataset",
+        "create_dataloaders",
+        "AgentSelectorModel",
+        "AgentSelectorTrainer",
+    ]
+except Exception:  # pragma: no cover - allow partial functionality
+    __all__: list[str] = []

--- a/training/reinforcement_learning.py
+++ b/training/reinforcement_learning.py
@@ -1,0 +1,57 @@
+"""Simple Q-learning trainer for agent selection."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Tuple
+
+from core.model_context import TaskContext
+
+
+@dataclass
+class QTableLearner:
+    """Q-learning based policy for choosing agents."""
+
+    learning_rate: float = 0.1
+    discount: float = 0.9
+    epsilon: float = 0.1
+    table: Dict[Tuple[str, str], float] = field(default_factory=dict)
+
+    def _state_key(self, task: TaskContext) -> str:
+        return task.task_type
+
+    def select_agent(self, task: TaskContext, agents: list[str]) -> str:
+        """Choose an agent using an epsilon-greedy policy."""
+        import random
+
+        if random.random() < self.epsilon:
+            return random.choice(agents)
+        state = self._state_key(task)
+        q_vals = {a: self.table.get((state, a), 0.0) for a in agents}
+        return max(q_vals, key=q_vals.get)
+
+    def learn(self, task: TaskContext, agent: str, reward: float) -> None:
+        """Update Q-table for given state/action pair."""
+        state = self._state_key(task)
+        key = (state, agent)
+        current = self.table.get(key, 0.0)
+        self.table[key] = current + self.learning_rate * (reward - current)
+
+    def save(self, path: str) -> None:
+        data = {"table": {f"{s}|{a}": v for (s, a), v in self.table.items()}}
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+
+    def load(self, path: str) -> None:
+        file = Path(path)
+        if not file.exists():
+            return
+        with open(file, encoding="utf-8") as fh:
+            data = json.load(fh)
+        table: Dict[Tuple[str, str], float] = {}
+        for key, val in data.get("table", {}).items():
+            state, agent = key.split("|", 1)
+            table[(state, agent)] = float(val)
+        self.table = table


### PR DESCRIPTION
## Summary
- introduce a simple Q‑learning based `QTableLearner`
- add unit tests for the learner
- create a new `federation_manager` service to forward tasks to remote Agent‑NN nodes
- document the Federation Manager component
- include Federation Manager in documentation navigation
- make training package imports optional

## Testing
- `ruff check training/reinforcement_learning.py training/__init__.py services/federation_manager tests/training/test_reinforcement_learning.py`
- `black --check training/reinforcement_learning.py services/federation_manager tests/training/test_reinforcement_learning.py training/__init__.py`
- `pytest tests/training/test_reinforcement_learning.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68655bc1597083248652022cde552a69