### PR TITLE
Expand OpenHands team

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,7 @@ PROMETHEUS_MULTIPROC_DIR=/tmp  # metrics directory
 ENABLE_OPENHANDS=false  # enable remote executor
 OPENHANDS_API_URL=http://localhost:8102  # executor URL
 OPENHANDS_JWT=changeme  # JWT for executor
+OPENHANDS_AGENT_PORTS=3001-3016  # range of agent ports
 
 # Storage Configuration
 DATA_DIR=./data  # base path

--- a/docs/integrations/OpenHands-Flowise-Flow.md
+++ b/docs/integrations/OpenHands-Flowise-Flow.md
@@ -1,21 +1,45 @@
 
-# Flowise-Flow für ein 10‑Agenten-Team mit OpenHands
+# Flowise-Flow für ein 16‑Agenten-Team mit OpenHands
 
-Wir erstellen einen Flowise-Workflow, der 10 lokal laufende OpenHands-Agenten (Ports 3001–3010) als Spezialisten (“Frontend”, “Backend”, “Dokumentation” etc.) ansteuert. Flowise selbst ist ein Open-Source Low‑Code-Werkzeug, mit dem man KI-Workflows visuell zusammenstellen kann. OpenHands ist ein Open-Source-Agentensystem, das Entwickleraufgaben per natürlicher Sprache ausführt. Im Flowise-Flow richten wir folgende Komponenten ein:
+Wir erstellen einen Flowise-Workflow, der 16 lokal laufende OpenHands-Agenten (Ports 3001–3016) als Spezialisten ansteuert. Neben den bisherigen Rollen wie „Frontend“, „Backend“ oder „Dokumentation“ sind zusätzliche Experten vertreten. Dazu zählen Android‑ und iOS‑Entwicklung, plattformübergreifende App-DevOps, Spezialisten für neuronale Netze, allgemeines ML/DL sowie LLM‑DevOps.
+
+**Agentenübersicht:**
+
+- Frontend Engineer
+- Backend Engineer
+- DevOps Specialist
+- Security Analyst
+- QA Tester
+- Technical Writer
+- Code Reviewer
+- Release Manager
+- Performance Optimizer
+- UX Designer
+- Android App DevOps
+- iOS App DevOps
+- Cross‑Platform App DevOps
+- Neural Network Expert
+- ML/DL Expert
+- LLM DevOps
+
+Flowise ist ein Open-Source Low‑Code-Werkzeug, mit dem man KI‑Workflows visuell zusammenstellen kann. OpenHands ist ein Open-Source-Agentensystem, das Entwickleraufgaben per natürlicher Sprache ausführt. Im Flowise‑Flow richten wir folgende Komponenten ein:
 
 ## Setup
 
 1. Stelle sicher, dass Python 3.10, Docker und Redis installiert sind.
 2. Installiere die Basis-Abhängigkeiten mit
 
-   ```bash
-   pip install -r requirements.txt
-   ./install_openhands_deps.sh  # optional
-   ```
+ ```bash
+  pip install -r requirements.txt
+  ./install_openhands_deps.sh  # optional
+  ```
+
 
    Alternativ kann `pip install -r requirements-openhands.txt` ausgeführt werden.
 
-3. Starte alle OpenHands-Agenten (Standardports 3001‑3010) und Flowise.
+   Die Ports der Agenten lassen sich über die Umgebungsvariable `OPENHANDS_AGENT_PORTS` steuern (Standard `3001-3016`).
+
+3. Starte alle OpenHands-Agenten (Standardports 3001‑3016) und Flowise.
 
 In Test- oder CI-Umgebungen ohne Docker kann der OpenHands-API-Server durch
 `tests/mocks/fake_openhands.py` simuliert werden. Die zugehörigen Tests
@@ -100,7 +124,7 @@ Die gesamte Logik sieht so aus: Nutzer gibt Aufgabe und Agenten-Auswahl ein. Anh
   }
   ```
 
-  (Analog für die Ports 3002–3010 der anderen Instanzen.) Dieses JSON entspricht dem cURL-Beispiel aus der OpenHands-Doku.
+  (Analog für die Ports 3002–3016 der anderen Instanzen.) Dieses JSON entspricht dem cURL-Beispiel aus der OpenHands-Doku.
 
 * *GET-Request Trajectory:*
 

--- a/sdk/cli/main.py
+++ b/sdk/cli/main.py
@@ -1101,7 +1101,7 @@ def feedback_log(agent: str) -> None:
 @openhands_app.command("list")
 def openhands_list() -> None:
     """List registered OpenHands agents."""
-    ports_env = os.getenv("OPENHANDS_AGENT_PORTS", "3001-3010")
+    ports_env = os.getenv("OPENHANDS_AGENT_PORTS", "3001-3016")
     if "-" in ports_env:
         start, end = [int(p) for p in ports_env.split("-")]
         ports = list(range(start, end + 1))
@@ -1117,7 +1117,7 @@ def openhands_list() -> None:
 @openhands_app.command("trigger")
 def openhands_trigger(task: str, agents: str = "all") -> None:
     """Trigger a task on one or multiple OpenHands agents."""
-    ports_env = os.getenv("OPENHANDS_AGENT_PORTS", "3001-3010")
+    ports_env = os.getenv("OPENHANDS_AGENT_PORTS", "3001-3016")
     if "-" in ports_env:
         start, end = [int(p) for p in ports_env.split("-")]
         ports = list(range(start, end + 1))


### PR DESCRIPTION
## Summary
- extend OpenHands agent port range in CLI and example env file
- document new specialized agents and updated port range

## Testing
- `ruff check .`
- `mypy mcp` *(fails: missing imports)*
- `pytest -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686617efef608324aa230e0978af7883