### PR TITLE
Add mobile development team workflow

### DIFF
--- a/integrations/flowise-agentnn/openhands_app.json
+++ b/integrations/flowise-agentnn/openhands_app.json
@@ -1,0 +1,3849 @@
+{
+  "nodes": [
+    {
+      "id": "start_0",
+      "type": "startNode",
+      "data": {
+        "id": "start_0",
+        "label": "Start",
+        "name": "start",
+        "type": "FormInput",
+        "category": "Start",
+        "formTitle": "Aufgabe und Agenten auswählen",
+        "formDescription": "Geben Sie eine Aufgabe ein und wählen Sie die Agenten aus.",
+        "inputParams": [
+          {
+            "label": "Aufgabe",
+            "name": "task",
+            "type": "string",
+            "placeholder": "Aufgabe..."
+          },
+          {
+            "label": "Agenten",
+            "name": "agents",
+            "type": "options",
+            "multiSelect": true,
+            "options": [
+              {
+                "label": "Android App DevOps",
+                "value": "Android App DevOps"
+              },
+              {
+                "label": "iOS App DevOps",
+                "value": "iOS App DevOps"
+              },
+              {
+                "label": "Crossplatform App DevOps",
+                "value": "Crossplatform App DevOps"
+              },
+              {
+                "label": "Mobile Security Analyst",
+                "value": "Mobile Security Analyst"
+              },
+              {
+                "label": "Mobile QA Tester",
+                "value": "Mobile QA Tester"
+              },
+              {
+                "label": "API Integration Engineer",
+                "value": "API Integration Engineer"
+              },
+              {
+                "label": "Mobile Performance Optimizer",
+                "value": "Mobile Performance Optimizer"
+              },
+              {
+                "label": "App Release Manager",
+                "value": "App Release Manager"
+              },
+              {
+                "label": "Mobile UX Designer",
+                "value": "Mobile UX Designer"
+              },
+              {
+                "label": "Desktop Compatibility Engineer",
+                "value": "Desktop Compatibility Engineer"
+              }
+            ]
+          }
+        ],
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "start_0-output-output"
+          }
+        ],
+        "inputs": {
+          "task": "",
+          "agents": []
+        }
+      },
+      "width": 300,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 100,
+        "y": 100
+      }
+    },
+    {
+      "id": "setVariable_1",
+      "type": "customNode",
+      "data": {
+        "id": "setVariable_1",
+        "label": "Setze Aufgabe",
+        "name": "setVariable",
+        "type": "SetVariable",
+        "category": "Utilities",
+        "description": "Speichert die Benutzeraufgabe in der Flow-Variable",
+        "inputParams": [
+          {
+            "label": "Variable Name",
+            "name": "variableName",
+            "type": "string"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "setVariable_1-input-input-string"
+          }
+        ],
+        "inputs": {
+          "variableName": "task",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "setVariable_1-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 300,
+      "height": 150,
+      "positionAbsolute": {
+        "x": 300,
+        "y": 100
+      }
+    },
+    {
+      "id": "if_0",
+      "type": "customNode",
+      "data": {
+        "id": "if_0",
+        "label": "If: Android App DevOps ausgewählt?",
+        "name": "ifElse",
+        "type": "IfElse",
+        "category": "Utilities",
+        "description": "Überprüft, ob der Agent Android App DevOps ausgewählt ist",
+        "inputParams": [
+          {
+            "label": "Condition",
+            "name": "condition",
+            "type": "boolean"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "if_0-input-input-string"
+          }
+        ],
+        "inputs": {
+          "condition": "{{ $flow.state.agents.includes('Android App DevOps') }}",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "true",
+            "label": "True",
+            "id": "if_0-output-true"
+          },
+          {
+            "name": "false",
+            "label": "False",
+            "id": "if_0-output-false"
+          }
+        ],
+        "outputs": {
+          "true": "True",
+          "false": "False"
+        }
+      },
+      "width": 300,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 100,
+        "y": 300
+      }
+    },
+    {
+      "id": "if_1",
+      "type": "customNode",
+      "data": {
+        "id": "if_1",
+        "label": "If: iOS App DevOps ausgewählt?",
+        "name": "ifElse",
+        "type": "IfElse",
+        "category": "Utilities",
+        "description": "Überprüft, ob der Agent iOS App DevOps ausgewählt ist",
+        "inputParams": [
+          {
+            "label": "Condition",
+            "name": "condition",
+            "type": "boolean"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "if_1-input-input-string"
+          }
+        ],
+        "inputs": {
+          "condition": "{{ $flow.state.agents.includes('iOS App DevOps') }}",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "true",
+            "label": "True",
+            "id": "if_1-output-true"
+          },
+          {
+            "name": "false",
+            "label": "False",
+            "id": "if_1-output-false"
+          }
+        ],
+        "outputs": {
+          "true": "True",
+          "false": "False"
+        }
+      },
+      "width": 300,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 350,
+        "y": 300
+      }
+    },
+    {
+      "id": "if_2",
+      "type": "customNode",
+      "data": {
+        "id": "if_2",
+        "label": "If: Crossplatform App DevOps ausgewählt?",
+        "name": "ifElse",
+        "type": "IfElse",
+        "category": "Utilities",
+        "description": "Überprüft, ob der Agent Crossplatform App DevOps ausgewählt ist",
+        "inputParams": [
+          {
+            "label": "Condition",
+            "name": "condition",
+            "type": "boolean"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "if_2-input-input-string"
+          }
+        ],
+        "inputs": {
+          "condition": "{{ $flow.state.agents.includes('Crossplatform App DevOps') }}",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "true",
+            "label": "True",
+            "id": "if_2-output-true"
+          },
+          {
+            "name": "false",
+            "label": "False",
+            "id": "if_2-output-false"
+          }
+        ],
+        "outputs": {
+          "true": "True",
+          "false": "False"
+        }
+      },
+      "width": 300,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 600,
+        "y": 300
+      }
+    },
+    {
+      "id": "if_3",
+      "type": "customNode",
+      "data": {
+        "id": "if_3",
+        "label": "If: Mobile Security Analyst ausgewählt?",
+        "name": "ifElse",
+        "type": "IfElse",
+        "category": "Utilities",
+        "description": "Überprüft, ob der Agent Mobile Security Analyst ausgewählt ist",
+        "inputParams": [
+          {
+            "label": "Condition",
+            "name": "condition",
+            "type": "boolean"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "if_3-input-input-string"
+          }
+        ],
+        "inputs": {
+          "condition": "{{ $flow.state.agents.includes('Mobile Security Analyst') }}",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "true",
+            "label": "True",
+            "id": "if_3-output-true"
+          },
+          {
+            "name": "false",
+            "label": "False",
+            "id": "if_3-output-false"
+          }
+        ],
+        "outputs": {
+          "true": "True",
+          "false": "False"
+        }
+      },
+      "width": 300,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 850,
+        "y": 300
+      }
+    },
+    {
+      "id": "if_4",
+      "type": "customNode",
+      "data": {
+        "id": "if_4",
+        "label": "If: Mobile QA Tester ausgewählt?",
+        "name": "ifElse",
+        "type": "IfElse",
+        "category": "Utilities",
+        "description": "Überprüft, ob der Agent Mobile QA Tester ausgewählt ist",
+        "inputParams": [
+          {
+            "label": "Condition",
+            "name": "condition",
+            "type": "boolean"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "if_4-input-input-string"
+          }
+        ],
+        "inputs": {
+          "condition": "{{ $flow.state.agents.includes('Mobile QA Tester') }}",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "true",
+            "label": "True",
+            "id": "if_4-output-true"
+          },
+          {
+            "name": "false",
+            "label": "False",
+            "id": "if_4-output-false"
+          }
+        ],
+        "outputs": {
+          "true": "True",
+          "false": "False"
+        }
+      },
+      "width": 300,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1100,
+        "y": 300
+      }
+    },
+    {
+      "id": "if_5",
+      "type": "customNode",
+      "data": {
+        "id": "if_5",
+        "label": "If: API Integration Engineer ausgewählt?",
+        "name": "ifElse",
+        "type": "IfElse",
+        "category": "Utilities",
+        "description": "Überprüft, ob der Agent API Integration Engineer ausgewählt ist",
+        "inputParams": [
+          {
+            "label": "Condition",
+            "name": "condition",
+            "type": "boolean"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "if_5-input-input-string"
+          }
+        ],
+        "inputs": {
+          "condition": "{{ $flow.state.agents.includes('API Integration Engineer') }}",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "true",
+            "label": "True",
+            "id": "if_5-output-true"
+          },
+          {
+            "name": "false",
+            "label": "False",
+            "id": "if_5-output-false"
+          }
+        ],
+        "outputs": {
+          "true": "True",
+          "false": "False"
+        }
+      },
+      "width": 300,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1350,
+        "y": 300
+      }
+    },
+    {
+      "id": "if_6",
+      "type": "customNode",
+      "data": {
+        "id": "if_6",
+        "label": "If: Mobile Performance Optimizer ausgewählt?",
+        "name": "ifElse",
+        "type": "IfElse",
+        "category": "Utilities",
+        "description": "Überprüft, ob der Agent Mobile Performance Optimizer ausgewählt ist",
+        "inputParams": [
+          {
+            "label": "Condition",
+            "name": "condition",
+            "type": "boolean"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "if_6-input-input-string"
+          }
+        ],
+        "inputs": {
+          "condition": "{{ $flow.state.agents.includes('Mobile Performance Optimizer') }}",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "true",
+            "label": "True",
+            "id": "if_6-output-true"
+          },
+          {
+            "name": "false",
+            "label": "False",
+            "id": "if_6-output-false"
+          }
+        ],
+        "outputs": {
+          "true": "True",
+          "false": "False"
+        }
+      },
+      "width": 300,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1600,
+        "y": 300
+      }
+    },
+    {
+      "id": "if_7",
+      "type": "customNode",
+      "data": {
+        "id": "if_7",
+        "label": "If: App Release Manager ausgewählt?",
+        "name": "ifElse",
+        "type": "IfElse",
+        "category": "Utilities",
+        "description": "Überprüft, ob der Agent App Release Manager ausgewählt ist",
+        "inputParams": [
+          {
+            "label": "Condition",
+            "name": "condition",
+            "type": "boolean"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "if_7-input-input-string"
+          }
+        ],
+        "inputs": {
+          "condition": "{{ $flow.state.agents.includes('App Release Manager') }}",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "true",
+            "label": "True",
+            "id": "if_7-output-true"
+          },
+          {
+            "name": "false",
+            "label": "False",
+            "id": "if_7-output-false"
+          }
+        ],
+        "outputs": {
+          "true": "True",
+          "false": "False"
+        }
+      },
+      "width": 300,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1850,
+        "y": 300
+      }
+    },
+    {
+      "id": "if_8",
+      "type": "customNode",
+      "data": {
+        "id": "if_8",
+        "label": "If: Mobile UX Designer ausgewählt?",
+        "name": "ifElse",
+        "type": "IfElse",
+        "category": "Utilities",
+        "description": "Überprüft, ob der Agent Mobile UX Designer ausgewählt ist",
+        "inputParams": [
+          {
+            "label": "Condition",
+            "name": "condition",
+            "type": "boolean"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "if_8-input-input-string"
+          }
+        ],
+        "inputs": {
+          "condition": "{{ $flow.state.agents.includes('Mobile UX Designer') }}",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "true",
+            "label": "True",
+            "id": "if_8-output-true"
+          },
+          {
+            "name": "false",
+            "label": "False",
+            "id": "if_8-output-false"
+          }
+        ],
+        "outputs": {
+          "true": "True",
+          "false": "False"
+        }
+      },
+      "width": 300,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 2100,
+        "y": 300
+      }
+    },
+    {
+      "id": "if_9",
+      "type": "customNode",
+      "data": {
+        "id": "if_9",
+        "label": "If: Desktop Compatibility Engineer ausgewählt?",
+        "name": "ifElse",
+        "type": "IfElse",
+        "category": "Utilities",
+        "description": "Überprüft, ob der Agent Desktop Compatibility Engineer ausgewählt ist",
+        "inputParams": [
+          {
+            "label": "Condition",
+            "name": "condition",
+            "type": "boolean"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "if_9-input-input-string"
+          }
+        ],
+        "inputs": {
+          "condition": "{{ $flow.state.agents.includes('Desktop Compatibility Engineer') }}",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "true",
+            "label": "True",
+            "id": "if_9-output-true"
+          },
+          {
+            "name": "false",
+            "label": "False",
+            "id": "if_9-output-false"
+          }
+        ],
+        "outputs": {
+          "true": "True",
+          "false": "False"
+        }
+      },
+      "width": 300,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 2350,
+        "y": 300
+      }
+    },
+    {
+      "id": "request_0_init",
+      "type": "customNode",
+      "data": {
+        "id": "request_0_init",
+        "label": "POST /api/conversations (Android App DevOps)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Sendet die Aufgabe an den Android App DevOps (Port 3011)",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          },
+          {
+            "label": "Body",
+            "name": "body",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_0_init-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "POST",
+          "url": "http://localhost:3011/api/conversations",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_ANDROID}}\"}",
+          "body": "{\"initial_user_msg\": \"{{ $flow.state.task }}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_0_init-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 100,
+        "y": 500
+      }
+    },
+    {
+      "id": "request_1_init",
+      "type": "customNode",
+      "data": {
+        "id": "request_1_init",
+        "label": "POST /api/conversations (iOS App DevOps)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Sendet die Aufgabe an den iOS App DevOps (Port 3012)",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          },
+          {
+            "label": "Body",
+            "name": "body",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_1_init-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "POST",
+          "url": "http://localhost:3012/api/conversations",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_IOS}}\"}",
+          "body": "{\"initial_user_msg\": \"{{ $flow.state.task }}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_1_init-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 350,
+        "y": 500
+      }
+    },
+    {
+      "id": "request_2_init",
+      "type": "customNode",
+      "data": {
+        "id": "request_2_init",
+        "label": "POST /api/conversations (Crossplatform App DevOps)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Sendet die Aufgabe an den Crossplatform App DevOps (Port 3013)",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          },
+          {
+            "label": "Body",
+            "name": "body",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_2_init-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "POST",
+          "url": "http://localhost:3013/api/conversations",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_CROSSPLATFORM}}\"}",
+          "body": "{\"initial_user_msg\": \"{{ $flow.state.task }}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_2_init-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 600,
+        "y": 500
+      }
+    },
+    {
+      "id": "request_3_init",
+      "type": "customNode",
+      "data": {
+        "id": "request_3_init",
+        "label": "POST /api/conversations (Mobile Security Analyst)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Sendet die Aufgabe an den Mobile Security Analyst (Port 3014)",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          },
+          {
+            "label": "Body",
+            "name": "body",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_3_init-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "POST",
+          "url": "http://localhost:3014/api/conversations",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_MOBILE_SECURITY}}\"}",
+          "body": "{\"initial_user_msg\": \"{{ $flow.state.task }}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_3_init-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 850,
+        "y": 500
+      }
+    },
+    {
+      "id": "request_4_init",
+      "type": "customNode",
+      "data": {
+        "id": "request_4_init",
+        "label": "POST /api/conversations (Mobile QA Tester)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Sendet die Aufgabe an den Mobile QA Tester (Port 3015)",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          },
+          {
+            "label": "Body",
+            "name": "body",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_4_init-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "POST",
+          "url": "http://localhost:3015/api/conversations",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_MOBILE_QA}}\"}",
+          "body": "{\"initial_user_msg\": \"{{ $flow.state.task }}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_4_init-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1100,
+        "y": 500
+      }
+    },
+    {
+      "id": "request_5_init",
+      "type": "customNode",
+      "data": {
+        "id": "request_5_init",
+        "label": "POST /api/conversations (API Integration Engineer)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Sendet die Aufgabe an den API Integration Engineer (Port 3016)",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          },
+          {
+            "label": "Body",
+            "name": "body",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_5_init-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "POST",
+          "url": "http://localhost:3016/api/conversations",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_API_INTEGRATION}}\"}",
+          "body": "{\"initial_user_msg\": \"{{ $flow.state.task }}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_5_init-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1350,
+        "y": 500
+      }
+    },
+    {
+      "id": "request_6_init",
+      "type": "customNode",
+      "data": {
+        "id": "request_6_init",
+        "label": "POST /api/conversations (Mobile Performance Optimizer)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Sendet die Aufgabe an den Mobile Performance Optimizer (Port 3017)",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          },
+          {
+            "label": "Body",
+            "name": "body",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_6_init-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "POST",
+          "url": "http://localhost:3017/api/conversations",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_MOBILE_PERFORMANCE}}\"}",
+          "body": "{\"initial_user_msg\": \"{{ $flow.state.task }}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_6_init-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1600,
+        "y": 500
+      }
+    },
+    {
+      "id": "request_7_init",
+      "type": "customNode",
+      "data": {
+        "id": "request_7_init",
+        "label": "POST /api/conversations (App Release Manager)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Sendet die Aufgabe an den App Release Manager (Port 3018)",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          },
+          {
+            "label": "Body",
+            "name": "body",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_7_init-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "POST",
+          "url": "http://localhost:3018/api/conversations",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_APP_RELEASE}}\"}",
+          "body": "{\"initial_user_msg\": \"{{ $flow.state.task }}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_7_init-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1850,
+        "y": 500
+      }
+    },
+    {
+      "id": "request_8_init",
+      "type": "customNode",
+      "data": {
+        "id": "request_8_init",
+        "label": "POST /api/conversations (Mobile UX Designer)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Sendet die Aufgabe an den Mobile UX Designer (Port 3019)",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          },
+          {
+            "label": "Body",
+            "name": "body",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_8_init-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "POST",
+          "url": "http://localhost:3019/api/conversations",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_MOBILE_UX}}\"}",
+          "body": "{\"initial_user_msg\": \"{{ $flow.state.task }}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_8_init-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 2100,
+        "y": 500
+      }
+    },
+    {
+      "id": "request_9_init",
+      "type": "customNode",
+      "data": {
+        "id": "request_9_init",
+        "label": "POST /api/conversations (Desktop Compatibility Engineer)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Sendet die Aufgabe an den Desktop Compatibility Engineer (Port 3020)",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          },
+          {
+            "label": "Body",
+            "name": "body",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_9_init-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "POST",
+          "url": "http://localhost:3020/api/conversations",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_DESKTOP_COMPAT}}\"}",
+          "body": "{\"initial_user_msg\": \"{{ $flow.state.task }}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_9_init-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 2350,
+        "y": 500
+      }
+    },
+    {
+      "id": "set_conv_0",
+      "type": "customNode",
+      "data": {
+        "id": "set_conv_0",
+        "label": "Setze convId (Android App DevOps)",
+        "name": "setVariable",
+        "type": "SetVariable",
+        "category": "Utilities",
+        "description": "Speichert die Conversation-ID des Android App DevOpss",
+        "inputParams": [
+          {
+            "label": "Variable Name",
+            "name": "variableName",
+            "type": "string"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "set_conv_0-input-input-string"
+          }
+        ],
+        "inputs": {
+          "variableName": "convId_Android_App_DevOps",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "set_conv_0-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 300,
+      "height": 150,
+      "positionAbsolute": {
+        "x": 100,
+        "y": 650
+      }
+    },
+    {
+      "id": "set_conv_1",
+      "type": "customNode",
+      "data": {
+        "id": "set_conv_1",
+        "label": "Setze convId (iOS App DevOps)",
+        "name": "setVariable",
+        "type": "SetVariable",
+        "category": "Utilities",
+        "description": "Speichert die Conversation-ID des iOS App DevOpss",
+        "inputParams": [
+          {
+            "label": "Variable Name",
+            "name": "variableName",
+            "type": "string"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "set_conv_1-input-input-string"
+          }
+        ],
+        "inputs": {
+          "variableName": "convId_iOS_App_DevOps",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "set_conv_1-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 300,
+      "height": 150,
+      "positionAbsolute": {
+        "x": 350,
+        "y": 650
+      }
+    },
+    {
+      "id": "set_conv_2",
+      "type": "customNode",
+      "data": {
+        "id": "set_conv_2",
+        "label": "Setze convId (Crossplatform App DevOps)",
+        "name": "setVariable",
+        "type": "SetVariable",
+        "category": "Utilities",
+        "description": "Speichert die Conversation-ID des Crossplatform App DevOpss",
+        "inputParams": [
+          {
+            "label": "Variable Name",
+            "name": "variableName",
+            "type": "string"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "set_conv_2-input-input-string"
+          }
+        ],
+        "inputs": {
+          "variableName": "convId_Crossplatform_App_DevOps",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "set_conv_2-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 300,
+      "height": 150,
+      "positionAbsolute": {
+        "x": 600,
+        "y": 650
+      }
+    },
+    {
+      "id": "set_conv_3",
+      "type": "customNode",
+      "data": {
+        "id": "set_conv_3",
+        "label": "Setze convId (Mobile Security Analyst)",
+        "name": "setVariable",
+        "type": "SetVariable",
+        "category": "Utilities",
+        "description": "Speichert die Conversation-ID des Mobile Security Analysts",
+        "inputParams": [
+          {
+            "label": "Variable Name",
+            "name": "variableName",
+            "type": "string"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "set_conv_3-input-input-string"
+          }
+        ],
+        "inputs": {
+          "variableName": "convId_Mobile_Security_Analyst",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "set_conv_3-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 300,
+      "height": 150,
+      "positionAbsolute": {
+        "x": 850,
+        "y": 650
+      }
+    },
+    {
+      "id": "set_conv_4",
+      "type": "customNode",
+      "data": {
+        "id": "set_conv_4",
+        "label": "Setze convId (Mobile QA Tester)",
+        "name": "setVariable",
+        "type": "SetVariable",
+        "category": "Utilities",
+        "description": "Speichert die Conversation-ID des Mobile QA Testers",
+        "inputParams": [
+          {
+            "label": "Variable Name",
+            "name": "variableName",
+            "type": "string"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "set_conv_4-input-input-string"
+          }
+        ],
+        "inputs": {
+          "variableName": "convId_Mobile_QA_Tester",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "set_conv_4-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 300,
+      "height": 150,
+      "positionAbsolute": {
+        "x": 1100,
+        "y": 650
+      }
+    },
+    {
+      "id": "set_conv_5",
+      "type": "customNode",
+      "data": {
+        "id": "set_conv_5",
+        "label": "Setze convId (API Integration Engineer)",
+        "name": "setVariable",
+        "type": "SetVariable",
+        "category": "Utilities",
+        "description": "Speichert die Conversation-ID des API Integration Engineers",
+        "inputParams": [
+          {
+            "label": "Variable Name",
+            "name": "variableName",
+            "type": "string"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "set_conv_5-input-input-string"
+          }
+        ],
+        "inputs": {
+          "variableName": "convId_API_Integration_Engineer",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "set_conv_5-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 300,
+      "height": 150,
+      "positionAbsolute": {
+        "x": 1350,
+        "y": 650
+      }
+    },
+    {
+      "id": "set_conv_6",
+      "type": "customNode",
+      "data": {
+        "id": "set_conv_6",
+        "label": "Setze convId (Mobile Performance Optimizer)",
+        "name": "setVariable",
+        "type": "SetVariable",
+        "category": "Utilities",
+        "description": "Speichert die Conversation-ID des Mobile Performance Optimizers",
+        "inputParams": [
+          {
+            "label": "Variable Name",
+            "name": "variableName",
+            "type": "string"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "set_conv_6-input-input-string"
+          }
+        ],
+        "inputs": {
+          "variableName": "convId_Mobile_Performance_Optimizer",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "set_conv_6-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 300,
+      "height": 150,
+      "positionAbsolute": {
+        "x": 1600,
+        "y": 650
+      }
+    },
+    {
+      "id": "set_conv_7",
+      "type": "customNode",
+      "data": {
+        "id": "set_conv_7",
+        "label": "Setze convId (App Release Manager)",
+        "name": "setVariable",
+        "type": "SetVariable",
+        "category": "Utilities",
+        "description": "Speichert die Conversation-ID des App Release Managers",
+        "inputParams": [
+          {
+            "label": "Variable Name",
+            "name": "variableName",
+            "type": "string"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "set_conv_7-input-input-string"
+          }
+        ],
+        "inputs": {
+          "variableName": "convId_App_Release_Manager",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "set_conv_7-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 300,
+      "height": 150,
+      "positionAbsolute": {
+        "x": 1850,
+        "y": 650
+      }
+    },
+    {
+      "id": "set_conv_8",
+      "type": "customNode",
+      "data": {
+        "id": "set_conv_8",
+        "label": "Setze convId (Mobile UX Designer)",
+        "name": "setVariable",
+        "type": "SetVariable",
+        "category": "Utilities",
+        "description": "Speichert die Conversation-ID des Mobile UX Designers",
+        "inputParams": [
+          {
+            "label": "Variable Name",
+            "name": "variableName",
+            "type": "string"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "set_conv_8-input-input-string"
+          }
+        ],
+        "inputs": {
+          "variableName": "convId_Mobile_UX_Designer",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "set_conv_8-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 300,
+      "height": 150,
+      "positionAbsolute": {
+        "x": 2100,
+        "y": 650
+      }
+    },
+    {
+      "id": "set_conv_9",
+      "type": "customNode",
+      "data": {
+        "id": "set_conv_9",
+        "label": "Setze convId (Desktop Compatibility Engineer)",
+        "name": "setVariable",
+        "type": "SetVariable",
+        "category": "Utilities",
+        "description": "Speichert die Conversation-ID des Desktop Compatibility Engineers",
+        "inputParams": [
+          {
+            "label": "Variable Name",
+            "name": "variableName",
+            "type": "string"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "set_conv_9-input-input-string"
+          }
+        ],
+        "inputs": {
+          "variableName": "convId_Desktop_Compatibility_Engineer",
+          "input": ""
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "set_conv_9-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 300,
+      "height": 150,
+      "positionAbsolute": {
+        "x": 2350,
+        "y": 650
+      }
+    },
+    {
+      "id": "request_0_traj",
+      "type": "customNode",
+      "data": {
+        "id": "request_0_traj",
+        "label": "GET /api/trajectory (Android App DevOps)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Ruft die Trajektorie des Android App DevOpss ab",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_0_traj-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "GET",
+          "url": "http://localhost:3011/api/trajectory?conversation_id={{ $flow.state.convId_Android_App_DevOps }}",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_ANDROID}}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_0_traj-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 100,
+        "y": 800
+      }
+    },
+    {
+      "id": "request_1_traj",
+      "type": "customNode",
+      "data": {
+        "id": "request_1_traj",
+        "label": "GET /api/trajectory (iOS App DevOps)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Ruft die Trajektorie des iOS App DevOpss ab",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_1_traj-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "GET",
+          "url": "http://localhost:3012/api/trajectory?conversation_id={{ $flow.state.convId_iOS_App_DevOps }}",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_IOS}}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_1_traj-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 350,
+        "y": 800
+      }
+    },
+    {
+      "id": "request_2_traj",
+      "type": "customNode",
+      "data": {
+        "id": "request_2_traj",
+        "label": "GET /api/trajectory (Crossplatform App DevOps)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Ruft die Trajektorie des Crossplatform App DevOpss ab",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_2_traj-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "GET",
+          "url": "http://localhost:3013/api/trajectory?conversation_id={{ $flow.state.convId_Crossplatform_App_DevOps }}",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_CROSSPLATFORM}}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_2_traj-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 600,
+        "y": 800
+      }
+    },
+    {
+      "id": "request_3_traj",
+      "type": "customNode",
+      "data": {
+        "id": "request_3_traj",
+        "label": "GET /api/trajectory (Mobile Security Analyst)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Ruft die Trajektorie des Mobile Security Analysts ab",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_3_traj-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "GET",
+          "url": "http://localhost:3014/api/trajectory?conversation_id={{ $flow.state.convId_Mobile_Security_Analyst }}",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_MOBILE_SECURITY}}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_3_traj-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 850,
+        "y": 800
+      }
+    },
+    {
+      "id": "request_4_traj",
+      "type": "customNode",
+      "data": {
+        "id": "request_4_traj",
+        "label": "GET /api/trajectory (Mobile QA Tester)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Ruft die Trajektorie des Mobile QA Testers ab",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_4_traj-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "GET",
+          "url": "http://localhost:3015/api/trajectory?conversation_id={{ $flow.state.convId_Mobile_QA_Tester }}",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_MOBILE_QA}}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_4_traj-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1100,
+        "y": 800
+      }
+    },
+    {
+      "id": "request_5_traj",
+      "type": "customNode",
+      "data": {
+        "id": "request_5_traj",
+        "label": "GET /api/trajectory (API Integration Engineer)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Ruft die Trajektorie des API Integration Engineers ab",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_5_traj-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "GET",
+          "url": "http://localhost:3016/api/trajectory?conversation_id={{ $flow.state.convId_API_Integration_Engineer }}",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_API_INTEGRATION}}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_5_traj-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1350,
+        "y": 800
+      }
+    },
+    {
+      "id": "request_6_traj",
+      "type": "customNode",
+      "data": {
+        "id": "request_6_traj",
+        "label": "GET /api/trajectory (Mobile Performance Optimizer)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Ruft die Trajektorie des Mobile Performance Optimizers ab",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_6_traj-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "GET",
+          "url": "http://localhost:3017/api/trajectory?conversation_id={{ $flow.state.convId_Mobile_Performance_Optimizer }}",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_MOBILE_PERFORMANCE}}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_6_traj-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1600,
+        "y": 800
+      }
+    },
+    {
+      "id": "request_7_traj",
+      "type": "customNode",
+      "data": {
+        "id": "request_7_traj",
+        "label": "GET /api/trajectory (App Release Manager)",
+        "name": "httpRequest",
+        "type": "HttpRequest",
+        "category": "Tools",
+        "description": "Ruft die Trajektorie des App Release Managers ab",
+        "inputParams": [
+          {
+            "label": "Method",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "label": "URL",
+            "name": "url",
+            "type": "string"
+          },
+          {
+            "label": "Headers",
+            "name": "headers",
+            "type": "json"
+          }
+        ],
+        "inputAnchors": [
+          {
+            "label": "Input",
+            "name": "input",
+            "type": "string",
+            "id": "request_7_traj-input-input-string"
+          }
+        ],
+        "inputs": {
+          "method": "GET",
+          "url": "http://localhost:3018/api/trajectory?conversation_id={{ $flow.state.convId_App_Release_Manager }}",
+          "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_APP_RELEASE}}\"}"
+        },
+        "outputAnchors": [
+          {
+            "name": "output",
+            "label": "Output",
+            "id": "request_7_traj-output-output"
+          }
+        ],
+        "outputs": {
+          "output": "output"
+        }
+      },
+      "width": 350,
+      "height": 200,
+      "positionAbsolute": {
+        "x": 1850,
+        "y": 800
+      }
+    },
+    {
+      "id": "request_8_traj",
+        "type": "customNode",
+        "data": {
+          "id": "request_8_traj",
+          "label": "GET /api/trajectory (Mobile UX Designer)",
+          "name": "httpRequest",
+          "type": "HttpRequest",
+          "category": "Tools",
+          "description": "Ruft die Trajektorie des Mobile UX Designers ab",
+          "inputParams": [
+            {
+              "label": "Method",
+              "name": "method",
+              "type": "string"
+            },
+            {
+              "label": "URL",
+              "name": "url",
+              "type": "string"
+            },
+            {
+              "label": "Headers",
+              "name": "headers",
+              "type": "json"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "request_8_traj-input-input-string"
+            }
+          ],
+          "inputs": {
+            "method": "GET",
+            "url": "http://localhost:3019/api/trajectory?conversation_id={{ $flow.state.convId_Mobile_UX_Designer }}",
+            "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_MOBILE_UX}}\"}"
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "request_8_traj-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 350,
+        "height": 200,
+        "positionAbsolute": {
+          "x": 2100,
+          "y": 800
+        }
+      },
+      {
+        "id": "request_9_traj",
+        "type": "customNode",
+        "data": {
+          "id": "request_9_traj",
+          "label": "GET /api/trajectory (Desktop Compatibility Engineer)",
+          "name": "httpRequest",
+          "type": "HttpRequest",
+          "category": "Tools",
+          "description": "Ruft die Trajektorie des Desktop Compatibility Engineers ab",
+          "inputParams": [
+            {
+              "label": "Method",
+              "name": "method",
+              "type": "string"
+            },
+            {
+              "label": "URL",
+              "name": "url",
+              "type": "string"
+            },
+            {
+              "label": "Headers",
+              "name": "headers",
+              "type": "json"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "request_9_traj-input-input-string"
+            }
+          ],
+          "inputs": {
+            "method": "GET",
+            "url": "http://localhost:3020/api/trajectory?conversation_id={{ $flow.state.convId_Desktop_Compatibility_Engineer }}",
+            "headers": "{\"Authorization\": \"Bearer {{secrets.TOKEN_DESKTOP_COMPAT}}\"}"
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "request_9_traj-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 350,
+        "height": 200,
+        "positionAbsolute": {
+          "x": 2350,
+          "y": 800
+        }
+      },
+      {
+        "id": "set_res_0",
+        "type": "customNode",
+        "data": {
+          "id": "set_res_0",
+          "label": "Setze Ergebnis (Android App DevOps)",
+          "name": "setVariable",
+          "type": "SetVariable",
+          "category": "Utilities",
+          "description": "Speichert das Ergebnis des Android App DevOpss",
+          "inputParams": [
+            {
+              "label": "Variable Name",
+              "name": "variableName",
+              "type": "string"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "set_res_0-input-input-string"
+            }
+          ],
+          "inputs": {
+            "variableName": "result_Android_App_DevOps",
+            "input": ""
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "set_res_0-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 300,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 100,
+          "y": 950
+        }
+      },
+      {
+        "id": "set_res_1",
+        "type": "customNode",
+        "data": {
+          "id": "set_res_1",
+          "label": "Setze Ergebnis (iOS App DevOps)",
+          "name": "setVariable",
+          "type": "SetVariable",
+          "category": "Utilities",
+          "description": "Speichert das Ergebnis des iOS App DevOpss",
+          "inputParams": [
+            {
+              "label": "Variable Name",
+              "name": "variableName",
+              "type": "string"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "set_res_1-input-input-string"
+            }
+          ],
+          "inputs": {
+            "variableName": "result_iOS_App_DevOps",
+            "input": ""
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "set_res_1-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 300,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 350,
+          "y": 950
+        }
+      },
+      {
+        "id": "set_res_2",
+        "type": "customNode",
+        "data": {
+          "id": "set_res_2",
+          "label": "Setze Ergebnis (Crossplatform App DevOps)",
+          "name": "setVariable",
+          "type": "SetVariable",
+          "category": "Utilities",
+          "description": "Speichert das Ergebnis des Crossplatform App DevOpss",
+          "inputParams": [
+            {
+              "label": "Variable Name",
+              "name": "variableName",
+              "type": "string"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "set_res_2-input-input-string"
+            }
+          ],
+          "inputs": {
+            "variableName": "result_Crossplatform_App_DevOps",
+            "input": ""
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "set_res_2-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 300,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 600,
+          "y": 950
+        }
+      },
+      {
+        "id": "set_res_3",
+        "type": "customNode",
+        "data": {
+          "id": "set_res_3",
+          "label": "Setze Ergebnis (Mobile Security Analyst)",
+          "name": "setVariable",
+          "type": "SetVariable",
+          "category": "Utilities",
+          "description": "Speichert das Ergebnis des Mobile Security Analysts",
+          "inputParams": [
+            {
+              "label": "Variable Name",
+              "name": "variableName",
+              "type": "string"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "set_res_3-input-input-string"
+            }
+          ],
+          "inputs": {
+            "variableName": "result_Mobile_Security_Analyst",
+            "input": ""
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "set_res_3-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 300,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 850,
+          "y": 950
+        }
+      },
+      {
+        "id": "set_res_4",
+        "type": "customNode",
+        "data": {
+          "id": "set_res_4",
+          "label": "Setze Ergebnis (Mobile QA Tester)",
+          "name": "setVariable",
+          "type": "SetVariable",
+          "category": "Utilities",
+          "description": "Speichert das Ergebnis des Mobile QA Testers",
+          "inputParams": [
+            {
+              "label": "Variable Name",
+              "name": "variableName",
+              "type": "string"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "set_res_4-input-input-string"
+            }
+          ],
+          "inputs": {
+            "variableName": "result_Mobile_QA_Tester",
+            "input": ""
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "set_res_4-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 300,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 1100,
+          "y": 950
+        }
+      },
+      {
+        "id": "set_res_5",
+        "type": "customNode",
+        "data": {
+          "id": "set_res_5",
+          "label": "Setze Ergebnis (API Integration Engineer)",
+          "name": "setVariable",
+          "type": "SetVariable",
+          "category": "Utilities",
+          "description": "Speichert das Ergebnis des API Integration Engineers",
+          "inputParams": [
+            {
+              "label": "Variable Name",
+              "name": "variableName",
+              "type": "string"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "set_res_5-input-input-string"
+            }
+          ],
+          "inputs": {
+            "variableName": "result_API_Integration_Engineer",
+            "input": ""
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "set_res_5-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 300,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 1350,
+          "y": 950
+        }
+      },
+      {
+        "id": "set_res_6",
+        "type": "customNode",
+        "data": {
+          "id": "set_res_6",
+          "label": "Setze Ergebnis (Mobile Performance Optimizer)",
+          "name": "setVariable",
+          "type": "SetVariable",
+          "category": "Utilities",
+          "description": "Speichert das Ergebnis des Mobile Performance Optimizers",
+          "inputParams": [
+            {
+              "label": "Variable Name",
+              "name": "variableName",
+              "type": "string"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "set_res_6-input-input-string"
+            }
+          ],
+          "inputs": {
+            "variableName": "result_Mobile_Performance_Optimizer",
+            "input": ""
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "set_res_6-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 300,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 1600,
+          "y": 950
+        }
+      },
+      {
+        "id": "set_res_7",
+        "type": "customNode",
+        "data": {
+          "id": "set_res_7",
+          "label": "Setze Ergebnis (App Release Manager)",
+          "name": "setVariable",
+          "type": "SetVariable",
+          "category": "Utilities",
+          "description": "Speichert das Ergebnis des App Release Managers",
+          "inputParams": [
+            {
+              "label": "Variable Name",
+              "name": "variableName",
+              "type": "string"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "set_res_7-input-input-string"
+            }
+          ],
+          "inputs": {
+            "variableName": "result_App_Release_Manager",
+            "input": ""
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "set_res_7-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 300,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 1850,
+          "y": 950
+        }
+      },
+      {
+        "id": "set_res_8",
+        "type": "customNode",
+        "data": {
+          "id": "set_res_8",
+          "label": "Setze Ergebnis (Mobile UX Designer)",
+          "name": "setVariable",
+          "type": "SetVariable",
+          "category": "Utilities",
+          "description": "Speichert das Ergebnis des Mobile UX Designers",
+          "inputParams": [
+            {
+              "label": "Variable Name",
+              "name": "variableName",
+              "type": "string"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "set_res_8-input-input-string"
+            }
+          ],
+          "inputs": {
+            "variableName": "result_Mobile_UX_Designer",
+            "input": ""
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "set_res_8-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 300,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 2100,
+          "y": 950
+        }
+      },
+      {
+        "id": "set_res_9",
+        "type": "customNode",
+        "data": {
+          "id": "set_res_9",
+          "label": "Setze Ergebnis (Desktop Compatibility Engineer)",
+          "name": "setVariable",
+          "type": "SetVariable",
+          "category": "Utilities",
+          "description": "Speichert das Ergebnis des Desktop Compatibility Engineers",
+          "inputParams": [
+            {
+              "label": "Variable Name",
+              "name": "variableName",
+              "type": "string"
+            }
+          ],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "set_res_9-input-input-string"
+            }
+          ],
+          "inputs": {
+            "variableName": "result_Desktop_Compatibility_Engineer",
+            "input": ""
+          },
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "set_res_9-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 300,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 2350,
+          "y": 950
+        }
+      },
+      {
+        "id": "output_0",
+        "type": "customNode",
+        "data": {
+          "id": "output_0",
+          "label": "Android App DevOps-Ausgabe",
+          "name": "assistantReply",
+          "type": "AssistantMessage",
+          "category": "Utilities",
+          "description": "Gibt das Ergebnis des Android App DevOpss aus",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "output_0-input-input-string"
+            }
+          ],
+          "inputs": {
+            "input": "Android App DevOps: {{ $flow.state.result_Android_App_DevOps }}"
+          },
+          "outputAnchors": [],
+          "outputs": {}
+        },
+        "width": 350,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 100,
+          "y": 1100
+        }
+      },
+      {
+        "id": "output_1",
+        "type": "customNode",
+        "data": {
+          "id": "output_1",
+          "label": "iOS App DevOps-Ausgabe",
+          "name": "assistantReply",
+          "type": "AssistantMessage",
+          "category": "Utilities",
+          "description": "Gibt das Ergebnis des iOS App DevOpss aus",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "output_1-input-input-string"
+            }
+          ],
+          "inputs": {
+            "input": "iOS App DevOps: {{ $flow.state.result_iOS_App_DevOps }}"
+          },
+          "outputAnchors": [],
+          "outputs": {}
+        },
+        "width": 350,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 350,
+          "y": 1100
+        }
+      },
+      {
+        "id": "output_2",
+        "type": "customNode",
+        "data": {
+          "id": "output_2",
+          "label": "Crossplatform App DevOps-Ausgabe",
+          "name": "assistantReply",
+          "type": "AssistantMessage",
+          "category": "Utilities",
+          "description": "Gibt das Ergebnis des Crossplatform App DevOpss aus",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "output_2-input-input-string"
+            }
+          ],
+          "inputs": {
+            "input": "Crossplatform App DevOps: {{ $flow.state.result_Crossplatform_App_DevOps }}"
+          },
+          "outputAnchors": [],
+          "outputs": {}
+        },
+        "width": 350,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 600,
+          "y": 1100
+        }
+      },
+      {
+        "id": "output_3",
+        "type": "customNode",
+        "data": {
+          "id": "output_3",
+          "label": "Mobile Security Analyst-Ausgabe",
+          "name": "assistantReply",
+          "type": "AssistantMessage",
+          "category": "Utilities",
+          "description": "Gibt das Ergebnis des Mobile Security Analysts aus",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "output_3-input-input-string"
+            }
+          ],
+          "inputs": {
+            "input": "Mobile Security Analyst: {{ $flow.state.result_Mobile_Security_Analyst }}"
+          },
+          "outputAnchors": [],
+          "outputs": {}
+        },
+        "width": 350,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 850,
+          "y": 1100
+        }
+      },
+      {
+        "id": "output_4",
+        "type": "customNode",
+        "data": {
+          "id": "output_4",
+          "label": "Mobile QA Tester-Ausgabe",
+          "name": "assistantReply",
+          "type": "AssistantMessage",
+          "category": "Utilities",
+          "description": "Gibt das Ergebnis des Mobile QA Testers aus",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "output_4-input-input-string"
+            }
+          ],
+          "inputs": {
+            "input": "Mobile QA Tester: {{ $flow.state.result_Mobile_QA_Tester }}"
+          },
+          "outputAnchors": [],
+          "outputs": {}
+        },
+        "width": 350,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 1100,
+          "y": 1100
+        }
+      },
+      {
+        "id": "output_5",
+        "type": "customNode",
+        "data": {
+          "id": "output_5",
+          "label": "API Integration Engineer-Ausgabe",
+          "name": "assistantReply",
+          "type": "AssistantMessage",
+          "category": "Utilities",
+          "description": "Gibt das Ergebnis des API Integration Engineers aus",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "output_5-input-input-string"
+            }
+          ],
+          "inputs": {
+            "input": "API Integration Engineer: {{ $flow.state.result_API_Integration_Engineer }}"
+          },
+          "outputAnchors": [],
+          "outputs": {}
+        },
+        "width": 350,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 1350,
+          "y": 1100
+        }
+      },
+      {
+        "id": "output_6",
+        "type": "customNode",
+        "data": {
+          "id": "output_6",
+          "label": "Mobile Performance Optimizer-Ausgabe",
+          "name": "assistantReply",
+          "type": "AssistantMessage",
+          "category": "Utilities",
+          "description": "Gibt das Ergebnis des Mobile Performance Optimizers aus",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "output_6-input-input-string"
+            }
+          ],
+          "inputs": {
+            "input": "Mobile Performance Optimizer: {{ $flow.state.result_Mobile_Performance_Optimizer }}"
+          },
+          "outputAnchors": [],
+          "outputs": {}
+        },
+        "width": 350,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 1600,
+          "y": 1100
+        }
+      },
+      {
+        "id": "output_7",
+        "type": "customNode",
+        "data": {
+          "id": "output_7",
+          "label": "App Release Manager-Ausgabe",
+          "name": "assistantReply",
+          "type": "AssistantMessage",
+          "category": "Utilities",
+          "description": "Gibt das Ergebnis des App Release Managers aus",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "output_7-input-input-string"
+            }
+          ],
+          "inputs": {
+            "input": "App Release Manager: {{ $flow.state.result_App_Release_Manager }}"
+          },
+          "outputAnchors": [],
+          "outputs": {}
+        },
+        "width": 350,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 1850,
+          "y": 1100
+        }
+      },
+      {
+        "id": "output_8",
+        "type": "customNode",
+        "data": {
+          "id": "output_8",
+          "label": "Mobile UX Designer-Ausgabe",
+          "name": "assistantReply",
+          "type": "AssistantMessage",
+          "category": "Utilities",
+          "description": "Gibt das Ergebnis des Mobile UX Designers aus",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "output_8-input-input-string"
+            }
+          ],
+          "inputs": {
+            "input": "Mobile UX Designer: {{ $flow.state.result_Mobile_UX_Designer }}"
+          },
+          "outputAnchors": [],
+          "outputs": {}
+        },
+        "width": 350,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 2100,
+          "y": 1100
+        }
+      },
+      {
+        "id": "output_9",
+        "type": "customNode",
+        "data": {
+          "id": "output_9",
+          "label": "Desktop Compatibility Engineer-Ausgabe",
+          "name": "assistantReply",
+          "type": "AssistantMessage",
+          "category": "Utilities",
+          "description": "Gibt das Ergebnis des Desktop Compatibility Engineers aus",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "output_9-input-input-string"
+            }
+          ],
+          "inputs": {
+            "input": "Desktop Compatibility Engineer: {{ $flow.state.result_Desktop_Compatibility_Engineer }}"
+          },
+          "outputAnchors": [],
+          "outputs": {}
+        },
+        "width": 350,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 2350,
+          "y": 1100
+        }
+      },
+      {
+        "id": "merge_results",
+        "type": "customNode",
+        "data": {
+          "id": "merge_results",
+          "label": "Ergebnisse zusammenführen",
+          "name": "merge",
+          "type": "Merge",
+          "category": "Utilities",
+          "description": "Fasst alle Einzelausgaben zusammen",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Eingabe 1",
+              "name": "branch1",
+              "type": "string",
+              "id": "merge_results-input-branch1"
+            },
+            {
+              "label": "Eingabe 2",
+              "name": "branch2",
+              "type": "string",
+              "id": "merge_results-input-branch2"
+            },
+            {
+              "label": "Eingabe 3",
+              "name": "branch3",
+              "type": "string",
+              "id": "merge_results-input-branch3"
+            },
+            {
+              "label": "Eingabe 4",
+              "name": "branch4",
+              "type": "string",
+              "id": "merge_results-input-branch4"
+            },
+            {
+              "label": "Eingabe 5",
+              "name": "branch5",
+              "type": "string",
+              "id": "merge_results-input-branch5"
+            },
+            {
+              "label": "Eingabe 6",
+              "name": "branch6",
+              "type": "string",
+              "id": "merge_results-input-branch6"
+            },
+            {
+              "label": "Eingabe 7",
+              "name": "branch7",
+              "type": "string",
+              "id": "merge_results-input-branch7"
+            },
+            {
+              "label": "Eingabe 8",
+              "name": "branch8",
+              "type": "string",
+              "id": "merge_results-input-branch8"
+            },
+            {
+              "label": "Eingabe 9",
+              "name": "branch9",
+              "type": "string",
+              "id": "merge_results-input-branch9"
+            },
+            {
+              "label": "Eingabe 10",
+              "name": "branch10",
+              "type": "string",
+              "id": "merge_results-input-branch10"
+            }
+          ],
+          "inputs": {},
+          "outputAnchors": [
+            {
+              "name": "output",
+              "label": "Output",
+              "id": "merge_results-output-output"
+            }
+          ],
+          "outputs": {
+            "output": "output"
+          }
+        },
+        "width": 300,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 1200,
+          "y": 1350
+        }
+      },
+      {
+        "id": "output_summary",
+        "type": "customNode",
+        "data": {
+          "id": "output_summary",
+          "label": "Zusammenfassung",
+          "name": "assistantReply",
+          "type": "AssistantMessage",
+          "category": "Utilities",
+          "description": "Gibt die zusammengefassten Ergebnisse aus",
+          "inputParams": [],
+          "inputAnchors": [
+            {
+              "label": "Input",
+              "name": "input",
+              "type": "string",
+              "id": "output_summary-input-input-string"
+            }
+          ],
+          "inputs": {
+            "input": "Zusammenfassung: Android App DevOps: {{ $flow.state.result_Android_App_DevOps }} iOS App DevOps: {{ $flow.state.result_iOS_App_DevOps }} Crossplatform App DevOps: {{ $flow.state.result_Crossplatform_App_DevOps }} Mobile Security Analyst: {{ $flow.state.result_Mobile_Security_Analyst }} Mobile QA Tester: {{ $flow.state.result_Mobile_QA_Tester }} API Integration Engineer: {{ $flow.state.result_API_Integration_Engineer }} Mobile Performance Optimizer: {{ $flow.state.result_Mobile_Performance_Optimizer }} App Release Manager: {{ $flow.state.result_App_Release_Manager }} Mobile UX Designer: {{ $flow.state.result_Mobile_UX_Designer }} Desktop Compatibility Engineer: {{ $flow.state.result_Desktop_Compatibility_Engineer }}"
+          },
+          "outputAnchors": [],
+          "outputs": {}
+        },
+        "width": 400,
+        "height": 150,
+        "positionAbsolute": {
+          "x": 1200,
+          "y": 1500
+        }
+      }
+  ],
+  "edges": [
+    {
+      "source": "start_0",
+      "sourceHandle": "start_0-output-output",
+      "target": "setVariable_1",
+      "targetHandle": "setVariable_1-input-input",
+      "type": "buttonedge",
+      "id": "start_0-setVariable_1"
+    },
+    {
+      "source": "setVariable_1",
+      "sourceHandle": "setVariable_1-output-output",
+      "target": "if_0",
+      "targetHandle": "if_0-input-input",
+      "type": "buttonedge",
+      "id": "setVariable_1-if_0"
+    },
+    {
+      "source": "setVariable_1",
+      "sourceHandle": "setVariable_1-output-output",
+      "target": "if_1",
+      "targetHandle": "if_1-input-input",
+      "type": "buttonedge",
+      "id": "setVariable_1-if_1"
+    },
+    {
+      "source": "setVariable_1",
+      "sourceHandle": "setVariable_1-output-output",
+      "target": "if_2",
+      "targetHandle": "if_2-input-input",
+      "type": "buttonedge",
+      "id": "setVariable_1-if_2"
+    },
+    {
+      "source": "setVariable_1",
+      "sourceHandle": "setVariable_1-output-output",
+      "target": "if_3",
+      "targetHandle": "if_3-input-input",
+      "type": "buttonedge",
+      "id": "setVariable_1-if_3"
+    },
+    {
+      "source": "setVariable_1",
+      "sourceHandle": "setVariable_1-output-output",
+      "target": "if_4",
+      "targetHandle": "if_4-input-input",
+      "type": "buttonedge",
+      "id": "setVariable_1-if_4"
+    },
+    {
+      "source": "setVariable_1",
+      "sourceHandle": "setVariable_1-output-output",
+      "target": "if_5",
+      "targetHandle": "if_5-input-input",
+      "type": "buttonedge",
+      "id": "setVariable_1-if_5"
+    },
+    {
+      "source": "setVariable_1",
+      "sourceHandle": "setVariable_1-output-output",
+      "target": "if_6",
+      "targetHandle": "if_6-input-input",
+      "type": "buttonedge",
+      "id": "setVariable_1-if_6"
+    },
+    {
+      "source": "setVariable_1",
+      "sourceHandle": "setVariable_1-output-output",
+      "target": "if_7",
+      "targetHandle": "if_7-input-input",
+      "type": "buttonedge",
+      "id": "setVariable_1-if_7"
+    },
+    {
+      "source": "setVariable_1",
+      "sourceHandle": "setVariable_1-output-output",
+      "target": "if_8",
+      "targetHandle": "if_8-input-input",
+      "type": "buttonedge",
+      "id": "setVariable_1-if_8"
+    },
+    {
+      "source": "setVariable_1",
+      "sourceHandle": "setVariable_1-output-output",
+      "target": "if_9",
+      "targetHandle": "if_9-input-input",
+      "type": "buttonedge",
+      "id": "setVariable_1-if_9"
+    },
+    {
+      "source": "if_0",
+      "sourceHandle": "if_0-output-true",
+      "target": "request_0_init",
+      "targetHandle": "request_0_init-input-input",
+      "type": "buttonedge",
+      "id": "if_0-request_0_init"
+    },
+    {
+      "source": "if_1",
+      "sourceHandle": "if_1-output-true",
+      "target": "request_1_init",
+      "targetHandle": "request_1_init-input-input",
+      "type": "buttonedge",
+      "id": "if_1-request_1_init"
+    },
+    {
+      "source": "if_2",
+      "sourceHandle": "if_2-output-true",
+      "target": "request_2_init",
+      "targetHandle": "request_2_init-input-input",
+      "type": "buttonedge",
+      "id": "if_2-request_2_init"
+    },
+    {
+      "source": "if_3",
+      "sourceHandle": "if_3-output-true",
+      "target": "request_3_init",
+      "targetHandle": "request_3_init-input-input",
+      "type": "buttonedge",
+      "id": "if_3-request_3_init"
+    },
+    {
+      "source": "if_4",
+      "sourceHandle": "if_4-output-true",
+      "target": "request_4_init",
+      "targetHandle": "request_4_init-input-input",
+      "type": "buttonedge",
+      "id": "if_4-request_4_init"
+    },
+    {
+      "source": "if_5",
+      "sourceHandle": "if_5-output-true",
+      "target": "request_5_init",
+      "targetHandle": "request_5_init-input-input",
+      "type": "buttonedge",
+      "id": "if_5-request_5_init"
+    },
+    {
+      "source": "if_6",
+      "sourceHandle": "if_6-output-true",
+      "target": "request_6_init",
+      "targetHandle": "request_6_init-input-input",
+      "type": "buttonedge",
+      "id": "if_6-request_6_init"
+    },
+    {
+      "source": "if_7",
+      "sourceHandle": "if_7-output-true",
+      "target": "request_7_init",
+      "targetHandle": "request_7_init-input-input",
+      "type": "buttonedge",
+      "id": "if_7-request_7_init"
+    },
+    {
+      "source": "if_8",
+      "sourceHandle": "if_8-output-true",
+      "target": "request_8_init",
+      "targetHandle": "request_8_init-input-input",
+      "type": "buttonedge",
+      "id": "if_8-request_8_init"
+    },
+    {
+      "source": "if_9",
+      "sourceHandle": "if_9-output-true",
+      "target": "request_9_init",
+      "targetHandle": "request_9_init-input-input",
+      "type": "buttonedge",
+      "id": "if_9-request_9_init"
+    },
+    {
+      "source": "request_0_init",
+      "sourceHandle": "request_0_init-output-output",
+      "target": "set_conv_0",
+      "targetHandle": "set_conv_0-input-input",
+      "type": "buttonedge",
+      "id": "request_0_init-set_conv_0"
+    },
+    {
+      "source": "request_1_init",
+      "sourceHandle": "request_1_init-output-output",
+      "target": "set_conv_1",
+      "targetHandle": "set_conv_1-input-input",
+      "type": "buttonedge",
+      "id": "request_1_init-set_conv_1"
+    },
+    {
+      "source": "request_2_init",
+      "sourceHandle": "request_2_init-output-output",
+      "target": "set_conv_2",
+      "targetHandle": "set_conv_2-input-input",
+      "type": "buttonedge",
+      "id": "request_2_init-set_conv_2"
+    },
+    {
+      "source": "request_3_init",
+      "sourceHandle": "request_3_init-output-output",
+      "target": "set_conv_3",
+      "targetHandle": "set_conv_3-input-input",
+      "type": "buttonedge",
+      "id": "request_3_init-set_conv_3"
+    },
+    {
+      "source": "request_4_init",
+      "sourceHandle": "request_4_init-output-output",
+      "target": "set_conv_4",
+      "targetHandle": "set_conv_4-input-input",
+      "type": "buttonedge",
+      "id": "request_4_init-set_conv_4"
+    },
+    {
+      "source": "request_5_init",
+      "sourceHandle": "request_5_init-output-output",
+      "target": "set_conv_5",
+      "targetHandle": "set_conv_5-input-input",
+      "type": "buttonedge",
+      "id": "request_5_init-set_conv_5"
+    },
+    {
+      "source": "request_6_init",
+      "sourceHandle": "request_6_init-output-output",
+      "target": "set_conv_6",
+      "targetHandle": "set_conv_6-input-input",
+      "type": "buttonedge",
+      "id": "request_6_init-set_conv_6"
+    },
+    {
+      "source": "request_7_init",
+      "sourceHandle": "request_7_init-output-output",
+      "target": "set_conv_7",
+      "targetHandle": "set_conv_7-input-input",
+      "type": "buttonedge",
+      "id": "request_7_init-set_conv_7"
+    },
+    {
+      "source": "request_8_init",
+      "sourceHandle": "request_8_init-output-output",
+      "target": "set_conv_8",
+      "targetHandle": "set_conv_8-input-input",
+      "type": "buttonedge",
+      "id": "request_8_init-set_conv_8"
+    },
+    {
+      "source": "request_9_init",
+      "sourceHandle": "request_9_init-output-output",
+      "target": "set_conv_9",
+      "targetHandle": "set_conv_9-input-input",
+      "type": "buttonedge",
+      "id": "request_9_init-set_conv_9"
+    },
+    {
+      "source": "set_conv_0",
+      "sourceHandle": "set_conv_0-output-output",
+      "target": "request_0_traj",
+      "targetHandle": "request_0_traj-input-input",
+      "type": "buttonedge",
+      "id": "set_conv_0-request_0_traj"
+    },
+    {
+      "source": "set_conv_1",
+      "sourceHandle": "set_conv_1-output-output",
+      "target": "request_1_traj",
+      "targetHandle": "request_1_traj-input-input",
+      "type": "buttonedge",
+      "id": "set_conv_1-request_1_traj"
+    },
+    {
+      "source": "set_conv_2",
+      "sourceHandle": "set_conv_2-output-output",
+      "target": "request_2_traj",
+      "targetHandle": "request_2_traj-input-input",
+      "type": "buttonedge",
+      "id": "set_conv_2-request_2_traj"
+    },
+    {
+      "source": "set_conv_3",
+      "sourceHandle": "set_conv_3-output-output",
+      "target": "request_3_traj",
+      "targetHandle": "request_3_traj-input-input",
+      "type": "buttonedge",
+      "id": "set_conv_3-request_3_traj"
+    },
+    {
+      "source": "set_conv_4",
+      "sourceHandle": "set_conv_4-output-output",
+      "target": "request_4_traj",
+      "targetHandle": "request_4_traj-input-input",
+      "type": "buttonedge",
+      "id": "set_conv_4-request_4_traj"
+    },
+    {
+      "source": "set_conv_5",
+      "sourceHandle": "set_conv_5-output-output",
+      "target": "request_5_traj",
+      "targetHandle": "request_5_traj-input-input",
+      "type": "buttonedge",
+      "id": "set_conv_5-request_5_traj"
+    },
+    {
+      "source": "set_conv_6",
+      "sourceHandle": "set_conv_6-output-output",
+      "target": "request_6_traj",
+      "targetHandle": "request_6_traj-input-input",
+      "type": "buttonedge",
+      "id": "set_conv_6-request_6_traj"
+    },
+    {
+      "source": "set_conv_7",
+      "sourceHandle": "set_conv_7-output-output",
+      "target": "request_7_traj",
+      "targetHandle": "request_7_traj-input-input",
+      "type": "buttonedge",
+      "id": "set_conv_7-request_7_traj"
+    },
+    {
+      "source": "set_conv_8",
+      "sourceHandle": "set_conv_8-output-output",
+      "target": "request_8_traj",
+      "targetHandle": "request_8_traj-input-input",
+      "type": "buttonedge",
+      "id": "set_conv_8-request_8_traj"
+    },
+    {
+      "source": "set_conv_9",
+      "sourceHandle": "set_conv_9-output-output",
+      "target": "request_9_traj",
+      "targetHandle": "request_9_traj-input-input",
+      "type": "buttonedge",
+      "id": "set_conv_9-request_9_traj"
+    },
+    {
+      "source": "request_0_traj",
+      "sourceHandle": "request_0_traj-output-output",
+      "target": "set_res_0",
+      "targetHandle": "set_res_0-input-input",
+      "type": "buttonedge",
+      "id": "request_0_traj-set_res_0"
+    },
+    {
+      "source": "request_1_traj",
+      "sourceHandle": "request_1_traj-output-output",
+      "target": "set_res_1",
+      "targetHandle": "set_res_1-input-input",
+      "type": "buttonedge",
+      "id": "request_1_traj-set_res_1"
+    },
+    {
+      "source": "request_2_traj",
+      "sourceHandle": "request_2_traj-output-output",
+      "target": "set_res_2",
+      "targetHandle": "set_res_2-input-input",
+      "type": "buttonedge",
+      "id": "request_2_traj-set_res_2"
+    },
+    {
+      "source": "request_3_traj",
+      "sourceHandle": "request_3_traj-output-output",
+      "target": "set_res_3",
+      "targetHandle": "set_res_3-input-input",
+      "type": "buttonedge",
+      "id": "request_3_traj-set_res_3"
+    },
+    {
+      "source": "request_4_traj",
+      "sourceHandle": "request_4_traj-output-output",
+      "target": "set_res_4",
+      "targetHandle": "set_res_4-input-input",
+      "type": "buttonedge",
+      "id": "request_4_traj-set_res_4"
+    },
+    {
+      "source": "request_5_traj",
+      "sourceHandle": "request_5_traj-output-output",
+      "target": "set_res_5",
+      "targetHandle": "set_res_5-input-input",
+      "type": "buttonedge",
+      "id": "request_5_traj-set_res_5"
+    },
+    {
+      "source": "request_6_traj",
+      "sourceHandle": "request_6_traj-output-output",
+      "target": "set_res_6",
+      "targetHandle": "set_res_6-input-input",
+      "type": "buttonedge",
+      "id": "request_6_traj-set_res_6"
+    },
+    {
+      "source": "request_7_traj",
+      "sourceHandle": "request_7_traj-output-output",
+      "target": "set_res_7",
+      "targetHandle": "set_res_7-input-input",
+      "type": "buttonedge",
+      "id": "request_7_traj-set_res_7"
+    },
+    {
+      "source": "request_8_traj",
+      "sourceHandle": "request_8_traj-output-output",
+      "target": "set_res_8",
+      "targetHandle": "set_res_8-input-input",
+      "type": "buttonedge",
+      "id": "request_8_traj-set_res_8"
+    },
+    {
+      "source": "request_9_traj",
+      "sourceHandle": "request_9_traj-output-output",
+      "target": "set_res_9",
+      "targetHandle": "set_res_9-input-input",
+      "type": "buttonedge",
+      "id": "request_9_traj-set_res_9"
+    },
+    {
+      "source": "set_res_0",
+      "sourceHandle": "set_res_0-output-output",
+      "target": "output_0",
+      "targetHandle": "output_0-input-input",
+      "type": "buttonedge",
+      "id": "set_res_0-output_0"
+    },
+    {
+      "source": "set_res_1",
+      "sourceHandle": "set_res_1-output-output",
+      "target": "output_1",
+      "targetHandle": "output_1-input-input",
+      "type": "buttonedge",
+      "id": "set_res_1-output_1"
+    },
+    {
+      "source": "set_res_2",
+      "sourceHandle": "set_res_2-output-output",
+      "target": "output_2",
+      "targetHandle": "output_2-input-input",
+      "type": "buttonedge",
+      "id": "set_res_2-output_2"
+    },
+    {
+      "source": "set_res_3",
+      "sourceHandle": "set_res_3-output-output",
+      "target": "output_3",
+      "targetHandle": "output_3-input-input",
+      "type": "buttonedge",
+      "id": "set_res_3-output_3"
+    },
+    {
+      "source": "set_res_4",
+      "sourceHandle": "set_res_4-output-output",
+      "target": "output_4",
+      "targetHandle": "output_4-input-input",
+      "type": "buttonedge",
+      "id": "set_res_4-output_4"
+    },
+    {
+      "source": "set_res_5",
+      "sourceHandle": "set_res_5-output-output",
+      "target": "output_5",
+      "targetHandle": "output_5-input-input",
+      "type": "buttonedge",
+      "id": "set_res_5-output_5"
+    },
+    {
+      "source": "set_res_6",
+      "sourceHandle": "set_res_6-output-output",
+      "target": "output_6",
+      "targetHandle": "output_6-input-input",
+      "type": "buttonedge",
+      "id": "set_res_6-output_6"
+    },
+    {
+      "source": "set_res_7",
+      "sourceHandle": "set_res_7-output-output",
+      "target": "output_7",
+      "targetHandle": "output_7-input-input",
+      "type": "buttonedge",
+      "id": "set_res_7-output_7"
+    },
+    {
+      "source": "set_res_8",
+      "sourceHandle": "set_res_8-output-output",
+      "target": "output_8",
+      "targetHandle": "output_8-input-input",
+      "type": "buttonedge",
+      "id": "set_res_8-output_8"
+    },
+    {
+      "source": "set_res_9",
+      "sourceHandle": "set_res_9-output-output",
+      "target": "output_9",
+      "targetHandle": "output_9-input-input",
+      "type": "buttonedge",
+      "id": "set_res_9-output_9"
+    },
+    {
+      "source": "set_res_0",
+      "sourceHandle": "set_res_0-output-output",
+      "target": "merge_results",
+      "targetHandle": "merge_results-input-branch1",
+      "type": "buttonedge",
+      "id": "set_res_0-merge_results"
+    },
+    {
+      "source": "set_res_1",
+      "sourceHandle": "set_res_1-output-output",
+      "target": "merge_results",
+      "targetHandle": "merge_results-input-branch2",
+      "type": "buttonedge",
+      "id": "set_res_1-merge_results"
+    },
+    {
+      "source": "set_res_2",
+      "sourceHandle": "set_res_2-output-output",
+      "target": "merge_results",
+      "targetHandle": "merge_results-input-branch3",
+      "type": "buttonedge",
+      "id": "set_res_2-merge_results"
+    },
+    {
+      "source": "set_res_3",
+      "sourceHandle": "set_res_3-output-output",
+      "target": "merge_results",
+      "targetHandle": "merge_results-input-branch4",
+      "type": "buttonedge",
+      "id": "set_res_3-merge_results"
+    },
+    {
+      "source": "set_res_4",
+      "sourceHandle": "set_res_4-output-output",
+      "target": "merge_results",
+      "targetHandle": "merge_results-input-branch5",
+      "type": "buttonedge",
+      "id": "set_res_4-merge_results"
+    },
+    {
+      "source": "set_res_5",
+      "sourceHandle": "set_res_5-output-output",
+      "target": "merge_results",
+      "targetHandle": "merge_results-input-branch6",
+      "type": "buttonedge",
+      "id": "set_res_5-merge_results"
+    },
+    {
+      "source": "set_res_6",
+      "sourceHandle": "set_res_6-output-output",
+      "target": "merge_results",
+      "targetHandle": "merge_results-input-branch7",
+      "type": "buttonedge",
+      "id": "set_res_6-merge_results"
+    },
+    {
+      "source": "set_res_7",
+      "sourceHandle": "set_res_7-output-output",
+      "target": "merge_results",
+      "targetHandle": "merge_results-input-branch8",
+      "type": "buttonedge",
+      "id": "set_res_7-merge_results"
+    },
+    {
+      "source": "set_res_8",
+      "sourceHandle": "set_res_8-output-output",
+      "target": "merge_results",
+      "targetHandle": "merge_results-input-branch9",
+      "type": "buttonedge",
+      "id": "set_res_8-merge_results"
+    },
+    {
+      "source": "set_res_9",
+      "sourceHandle": "set_res_9-output-output",
+      "target": "merge_results",
+      "targetHandle": "merge_results-input-branch10",
+      "type": "buttonedge",
+      "id": "set_res_9-merge_results"
+    },
+    {
+      "source": "merge_results",
+      "sourceHandle": "merge_results-output-output",
+      "target": "output_summary",
+      "targetHandle": "output_summary-input-input",
+      "type": "buttonedge",
+      "id": "merge_results-output_summary"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- duplicate the existing openhands FlowiseAI workflow
- specialize a second team for mobile and cross-platform app development
- add 10 dedicated app dev agents with their own ports and tokens

## Testing
- `ruff check .`
- `mypy mcp` *(fails: missing imports)*
- `pytest` *(fails: ModuleNotFoundError for fastapi and others)*

------
https://chatgpt.com/codex/tasks/task_e_68662aac2e4c8324833125eadc6a1f76