### PR TITLE
Add agent registry API tests and update strategy

### DIFF
--- a/docs/test_strategy.md
+++ b/docs/test_strategy.md
@@ -11,3 +11,14 @@ such as the dispatcher legacy routing fallback.
 
 Run `./tests/ci_check.sh` locally or via CI which executes ruff, mypy and pytest
 with coverage output in HTML and JSON format.
+
+## Markers
+
+All tests are tagged with either `@pytest.mark.unit` or `@pytest.mark.integration`. The default collection
+runs only unit tests unless `--run-integration` is provided. This behavior is implemented in `tests/conftest.py`.
+
+## Agent registry coverage
+
+Iteration 3 adds focused unit tests for the `AgentRegistryService` and its API routes. The tests verify
+metric counters, status handling and persistence of profile updates via the REST interface.
+Using `tmp_path` ensures profile files are isolated.

--- a/tests/registry/test_service_metrics.py
+++ b/tests/registry/test_service_metrics.py
@@ -1,0 +1,30 @@
+import pytest
+
+from services.agent_registry.service import AgentRegistryService
+from services.agent_registry.schemas import AgentInfo
+from core.metrics_utils import TASKS_PROCESSED
+
+
+@pytest.mark.unit
+def test_service_metrics_increment():
+    service = AgentRegistryService()
+    info = AgentInfo(name="demo", url="http://demo")
+    start = TASKS_PROCESSED.labels("agent_registry")._value.get()
+    service.register_agent(info)
+    after_register = TASKS_PROCESSED.labels("agent_registry")._value.get()
+    assert after_register == start + 1
+
+    service.list_agents()
+    after_list = TASKS_PROCESSED.labels("agent_registry")._value.get()
+    assert after_list == after_register + 1
+
+    service.get_agent(info.id)
+    after_get = TASKS_PROCESSED.labels("agent_registry")._value.get()
+    assert after_get == after_list + 1
+
+
+@pytest.mark.unit
+def test_update_and_get_status():
+    service = AgentRegistryService()
+    service.update_status("agent", {"progress": 50})
+    assert service.get_status("agent") == {"progress": 50}

--- a/tests/registry/test_status.py
+++ b/tests/registry/test_status.py
@@ -1,0 +1,44 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from services.agent_registry.routes import router, service
+from services.agent_registry.schemas import AgentInfo
+from core.agent_profile import AgentIdentity
+
+
+@pytest.mark.unit
+def test_agent_status_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENT_PROFILE_DIR", str(tmp_path))
+    app = FastAPI()
+    app.include_router(router)
+
+    service._agents.clear()
+    service._status.clear()
+
+    service.register_agent(AgentInfo(name="writer_agent", url="http://w"))
+    AgentIdentity(
+        name="writer_agent",
+        role="writer",
+        traits={},
+        skills=[],
+        memory_index=None,
+        created_at="now",
+    ).save()
+
+    client = TestClient(app)
+    payload = {"last_response_duration": 2.0, "tasks_in_progress": 4}
+    resp = client.post("/agent_status/writer_agent", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+    resp = client.get("/agent_status/writer_agent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["tasks_in_progress"] == 4
+    assert data["avg_response_time"] == 2.0
+    assert data["load_factor"] == 0.4
+
+    profile = AgentIdentity.load("writer_agent")
+    assert profile.avg_response_time == 2.0
+    assert profile.load_factor == 0.4


### PR DESCRIPTION
## Summary
- add unit tests for AgentRegistryService metrics and status
- test REST endpoints for updating and retrieving agent status
- document usage of pytest markers and new registry tests in test strategy

## Testing
- `./tests/ci_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_686662250ccc832495a4bbae0627bf08