### PR TITLE
Add CLI tests for rating and feedback

### DIFF
--- a/docs/test_strategy.md
+++ b/docs/test_strategy.md
@@ -37,3 +37,11 @@ independent from the rest of the system.
 Iteration 4 focuses on failure scenarios for the plugin agent service. Tests
 cover unknown tool names and invalid plugin inputs so that the service returns
 informative error messages instead of raising exceptions.
+
+## CLI-Kommandos
+
+Iteration 5 fügt gezielte Tests für die Befehlszeile hinzu. Die neuen Fälle
+verifizieren Fehlermeldungen bei ungültigen Bewertungen und eine korrekte
+Authentifizierungsprüfung beim Absenden von Feedback. Dazu wird der
+`typer.CliRunner` verwendet und HTTP-Aufrufe werden mit Dummy-Objekten
+simuliert.

--- a/tests/cli/test_rate_feedback.py
+++ b/tests/cli/test_rate_feedback.py
@@ -1,0 +1,66 @@
+import sys
+import types
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+sys.modules.setdefault(
+    "core.crypto",
+    types.SimpleNamespace(
+        generate_keypair=lambda *a, **k: None,
+        verify_signature=lambda *a, **k: True,
+    ),
+)
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+
+from sdk.cli.main import app  # noqa: E402
+from core.agent_profile import AgentIdentity  # noqa: E402
+from core.audit_log import AuditLog  # noqa: E402
+
+
+@pytest.mark.unit
+def test_rate_invalid_score(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENT_PROFILE_DIR", str(tmp_path))
+    monkeypatch.setenv("RATING_DIR", str(tmp_path))
+    # create dummy profile for to_agent so update_reputation works if called
+    AgentIdentity(name="to", role="", traits={}, skills=[], memory_index=None, created_at="now").save()
+    monkeypatch.setattr(AuditLog, "write", lambda self, entry: "id")
+    runner = CliRunner()
+    result = runner.invoke(app, ["rate", "from", "to", "--score", "1.5"])
+    assert result.exit_code == 1
+    assert "invalid score" in result.stdout
+
+
+class DummyClient:
+    def post_feedback(self, session, payload):
+        request = httpx.Request("POST", "http://example")
+        response = httpx.Response(401, request=request)
+        raise httpx.HTTPStatusError("unauthorized", request=request, response=response)
+
+
+@pytest.mark.unit
+def test_feedback_submit_auth(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENT_PROFILE_DIR", str(tmp_path))
+    monkeypatch.setattr("sdk.cli.main.AgentClient", lambda: DummyClient())
+    runner = CliRunner()
+    result = runner.invoke(app, ["feedback", "submit", "sess", "--score", "1", "--comment", "hi"])
+    assert result.exit_code == 1
+    assert "Nicht autorisiert" in result.stdout


### PR DESCRIPTION
## Summary
- expand CLI tests to cover `rate` and `feedback submit`
- document CLI test coverage in test strategy

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest tests/cli/test_rate_feedback.py -q`
- `pytest tests/cli/test_submit.py tests/cli/test_agent_evolve.py tests/cli/test_config_check.py tests/cli/test_model_run_list.py tests/cli/test_rate_feedback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68666ae42680832484840b115b621e79