### PR TITLE
Implement CreateTask Flowise node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ integrations/n8n-agentnn/node_modules/
 integrations/n8n-agentnn/dist/
 integrations/flowise-agentnn/node_modules/
 integrations/flowise-agentnn/dist/
+integrations/flowise-nodes/node_modules/
 *.env
 frontend/agent-ui/dist/

--- a/docs/flowise_nodes.md
+++ b/docs/flowise_nodes.md
@@ -20,3 +20,26 @@ Beispielaufruf:
 const node = new ListAgents('http://localhost:8000');
 const agents = await node.run();
 ```
+
+## CreateTask
+
+* **Typ:** Task
+* **Datei:** `integrations/flowise-nodes/CreateTask.ts`
+* **Beschreibung:** Erstellt einen neuen Task beim Dispatcher.
+* **Parameter:**
+  - `endpoint` (string): Basis-URL des Dispatchers.
+  - `taskType` (string): Typ des Tasks, Standard `chat`.
+  - `input` (object): Nutzlast des Tasks.
+  - `path` (string): API-Pfad, standardmäßig `/tasks`.
+  - `method` (string): HTTP-Methode, standardmäßig `POST`.
+  - `headers` (object): optionale HTTP-Header.
+  - `timeout` (number): Timeout in Millisekunden.
+* **Rückgabe:** JSON-Objekt mit dem API-Ergebnis oder Fehlermeldung.
+
+Beispielaufruf:
+
+```ts
+const node = new CreateTask('http://localhost:8000', 'chat', {prompt: 'Hi'});
+const result = await node.run();
+```
+

--- a/integrations/flowise-nodes/CreateTask.ts
+++ b/integrations/flowise-nodes/CreateTask.ts
@@ -1,0 +1,31 @@
+import axios, { AxiosRequestConfig } from 'axios';
+
+export default class CreateTask {
+  constructor(
+    private endpoint: string,
+    private taskType = 'chat',
+    private input: unknown = {},
+    private path = '/tasks',
+    private method: 'POST' | 'GET' | 'PUT' | 'DELETE' = 'POST',
+    private headers: Record<string, string> = {},
+    private timeout = 10000
+  ) {}
+
+  async run(): Promise<any> {
+    const url = `${this.endpoint.replace(/\/$/, '')}${this.path}`;
+    const body = { task_type: this.taskType, input: this.input };
+    const opts: AxiosRequestConfig = {
+      url,
+      method: this.method,
+      data: body,
+      headers: this.headers,
+      timeout: this.timeout,
+    };
+    try {
+      const response = await axios.request(opts);
+      return response.data;
+    } catch (err: any) {
+      return { error: err.message ?? String(err) };
+    }
+  }
+}

--- a/integrations/flowise-nodes/create_task.node.json
+++ b/integrations/flowise-nodes/create_task.node.json
@@ -1,0 +1,16 @@
+{
+  "name": "CreateTask",
+  "description": "Create a new task via Agent-NN dispatcher",
+  "inputs": [
+    {"name": "endpoint", "type": "string", "default": "http://localhost:8000"},
+    {"name": "taskType", "type": "string", "default": "chat"},
+    {"name": "input", "type": "object", "default": {}},
+    {"name": "path", "type": "string", "default": "/tasks"},
+    {"name": "method", "type": "string", "default": "POST"},
+    {"name": "headers", "type": "object", "default": {}},
+    {"name": "timeout", "type": "number", "default": 10000}
+  ],
+  "outputs": [
+    {"name": "result", "type": "object"}
+  ]
+}

--- a/integrations/flowise-nodes/dist/CreateTask.d.ts
+++ b/integrations/flowise-nodes/dist/CreateTask.d.ts
@@ -1,0 +1,11 @@
+export default class CreateTask {
+    private endpoint;
+    private taskType;
+    private input;
+    private path;
+    private method;
+    private headers;
+    private timeout;
+    constructor(endpoint: string, taskType?: string, input?: unknown, path?: string, method?: 'POST' | 'GET' | 'PUT' | 'DELETE', headers?: Record<string, string>, timeout?: number);
+    run(): Promise<any>;
+}

--- a/integrations/flowise-nodes/dist/CreateTask.js
+++ b/integrations/flowise-nodes/dist/CreateTask.js
@@ -1,0 +1,45 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const axios_1 = require("axios");
+class CreateTask {
+    constructor(endpoint, taskType = 'chat', input = {}, path = '/tasks', method = 'POST', headers = {}, timeout = 10000) {
+        this.endpoint = endpoint;
+        this.taskType = taskType;
+        this.input = input;
+        this.path = path;
+        this.method = method;
+        this.headers = headers;
+        this.timeout = timeout;
+    }
+    run() {
+        return __awaiter(this, void 0, void 0, function* () {
+            var _a;
+            const url = `${this.endpoint.replace(/\/$/, '')}${this.path}`;
+            const body = { task_type: this.taskType, input: this.input };
+            const opts = {
+                url,
+                method: this.method,
+                data: body,
+                headers: this.headers,
+                timeout: this.timeout,
+            };
+            try {
+                const response = yield axios_1.default.request(opts);
+                return response.data;
+            }
+            catch (err) {
+                return { error: (_a = err.message) !== null && _a !== void 0 ? _a : String(err) };
+            }
+        });
+    }
+}
+exports.default = CreateTask;


### PR DESCRIPTION
## Summary
- add CreateTask Flowise node with HTTP call to dispatcher
- document CreateTask node in docs/flowise_nodes.md
- ignore node_modules in flowise-nodes

## Testing
- `npm install && npx tsc` in `integrations/flowise-nodes`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68666fa068c0832498f426f01cb62165