### PR TITLE
Automate Flowise plugin packaging

### DIFF
--- a/docs/flowise_plugin.md
+++ b/docs/flowise_plugin.md
@@ -1,0 +1,27 @@
+# Flowise Plugin Bundle
+
+Dieses Dokument beschreibt, wie alle Agent‑NN Nodes als fertiges Flowise‑Plugin bereitgestellt werden.
+Ein Manifest `flowise-plugin.json` listet die enthaltenen Komponenten auf und erleichtert die Installation.
+
+## Manifest erzeugen
+
+```bash
+python tools/generate_flowise_plugin.py
+```
+
+Das Skript liest die Node‑Dateien aus `integrations/flowise-nodes` und erzeugt ein Manifest mit Name, Version und Node‑Liste.
+
+## Plugin erstellen
+
+```bash
+python tools/package_plugin.py --output agentnn_flowise_plugin.zip
+```
+
+Damit werden Node‑Definitionen, JavaScript-Dateien und das Manifest zu einem Zip‑Archiv gebündelt.
+
+## Installation
+
+1. Lade das Archiv im Flowise‑Plugin-Manager hoch oder kopiere es in das Plugin-Verzeichnis.
+2. Starte Flowise neu. Die Agent‑NN Nodes erscheinen anschließend unter der Kategorie **Agent-NN**.
+
+![Plugin Example](integrations/flowise_example.png)

--- a/flowise_deploy.py
+++ b/flowise_deploy.py
@@ -8,6 +8,9 @@ from pathlib import Path
 
 import httpx
 
+from tools.generate_flowise_plugin import generate_manifest
+from tools.package_plugin import create_archive
+
 DEFAULT_DEST = Path.home() / ".flowise" / "nodes" / "agent-nn"
 
 
@@ -40,9 +43,19 @@ def main() -> None:
     parser.add_argument("--src", type=Path, default=Path("integrations/flowise-nodes"))
     parser.add_argument("--dest", type=Path, default=DEFAULT_DEST)
     parser.add_argument("--reload-url", help="Flowise reload endpoint")
+    parser.add_argument(
+        "--build-plugin",
+        type=Path,
+        metavar="ARCHIVE",
+        help="Create a plugin archive after deployment",
+    )
     args = parser.parse_args()
 
     deploy(args.src, args.dest, args.reload_url)
+
+    if args.build_plugin:
+        manifest = generate_manifest(args.src, Path("flowise-plugin.json"))
+        create_archive(args.src, manifest, args.build_plugin)
 
 
 if __name__ == "__main__":

--- a/tools/generate_flowise_plugin.py
+++ b/tools/generate_flowise_plugin.py
@@ -1,0 +1,48 @@
+"""Generate a Flowise plugin manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_NODE_DIR = Path("integrations/flowise-nodes")
+DEFAULT_OUTFILE = Path("flowise-plugin.json")
+
+
+def collect_nodes(node_dir: Path) -> list[str]:
+    """Return Flowise node names within *node_dir*."""
+    nodes: list[str] = []
+    for file in sorted(node_dir.glob("*.node.json")):
+        data = json.loads(file.read_text())
+        nodes.append(data.get("name", file.stem))
+    return nodes
+
+
+def generate_manifest(node_dir: Path, out_file: Path) -> Path:
+    """Create plugin manifest from nodes in *node_dir* and store it at *out_file*."""
+    version = Path("VERSION").read_text().strip()
+    manifest = {
+        "name": "agent-nn",
+        "version": version,
+        "description": "Agent-NN Flowise nodes",
+        "nodes": collect_nodes(node_dir),
+        "author": "Agent-NN Team",
+        "keywords": ["agent-nn", "flowise", "plugin"],
+    }
+    out_file.write_text(json.dumps(manifest, indent=2))
+    return out_file
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate flowise-plugin.json")
+    parser.add_argument("--node-dir", type=Path, default=DEFAULT_NODE_DIR)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUTFILE)
+    args = parser.parse_args()
+
+    manifest_path = generate_manifest(args.node_dir, args.out)
+    print(f"Wrote {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/package_plugin.py
+++ b/tools/package_plugin.py
@@ -1,0 +1,43 @@
+"""Create an archive with Flowise nodes and manifest."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import tempfile
+from pathlib import Path
+
+DEFAULT_NODE_DIR = Path("integrations/flowise-nodes")
+DEFAULT_MANIFEST = Path("flowise-plugin.json")
+DEFAULT_OUTPUT = Path("agentnn_flowise_plugin.zip")
+
+
+def create_archive(node_dir: Path, manifest: Path, output: Path) -> Path:
+    """Bundle files into *output* archive and return the path."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        for item in node_dir.glob("*.node.json"):
+            shutil.copy2(item, tmp_dir / item.name)
+        dist = node_dir / "dist"
+        if dist.is_dir():
+            for js in dist.glob("*.js"):
+                shutil.copy2(js, tmp_dir / js.name)
+        shutil.copy2(manifest, tmp_dir / manifest.name)
+        base_name = output.with_suffix("")
+        shutil.make_archive(str(base_name), output.suffix.lstrip("."), tmp_dir)
+    return output
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Package Flowise plugin")
+    parser.add_argument("--node-dir", type=Path, default=DEFAULT_NODE_DIR)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    archive = create_archive(args.node_dir, args.manifest, args.output)
+    print(f"Created {archive}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide script to create `flowise-plugin.json`
- add helper to bundle nodes and manifest into an archive
- extend `flowise_deploy.py` with optional plugin build
- document plugin workflow

## Testing
- `ruff check tools/generate_flowise_plugin.py tools/package_plugin.py flowise_deploy.py`
- `bash tests/ci_check.sh` *(fails: pytest --cov not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6866b636c548832490bce7c67d671bf2