### PR TITLE
Add FlowiseHub manifest support

### DIFF
--- a/README.plugin.md
+++ b/README.plugin.md
@@ -22,3 +22,5 @@ python flowise_deploy.py --dest ~/.flowise/nodes/agent-nn --build-plugin agentnn
 | 1.0.4 | 1.3 |
 
 The license follows the main repository (MIT).
+
+See [docs/flowise_plugin.md](docs/flowise_plugin.md) for detailed instructions.

--- a/docs/flowisehub_publish.md
+++ b/docs/flowisehub_publish.md
@@ -1,0 +1,30 @@
+# FlowiseHub Publishing Guide
+
+This document explains how to publish the Agent-NN Flowise plugin to FlowiseHub or any compatible registry.
+
+## Preparation
+
+1. Generate the plugin manifest:
+   ```bash
+   python tools/generate_flowise_plugin.py
+   ```
+2. Validate the manifest locally:
+   ```bash
+   python tools/validate_plugin_manifest.py
+   ```
+3. Package the nodes and manifest:
+   ```bash
+   python tools/package_plugin.py --output agentnn_flowise_plugin.zip
+   ```
+
+The archive contains the compiled JavaScript files, node definitions and `flowise-plugin.json`.
+
+## Repository and Release
+
+Tag a GitHub release to provide a stable download link. The repository URL is
+<https://github.com/EcoSphereNetwork/Agent-NN>. GitHub Pages can host a preview page under `dist/index.html` with screenshots and usage instructions.
+
+## Submitting to FlowiseHub
+
+Upload the generated archive or reference the release page in FlowiseHub. Ensure that `flowise-plugin.json` includes the fields `repository`, `homepage` and `license` so that users can verify the source and terms.
+

--- a/flowise-plugin.json
+++ b/flowise-plugin.json
@@ -14,5 +14,8 @@
     "agent-nn",
     "flowise",
     "plugin"
-  ]
+  ],
+  "repository": "https://github.com/EcoSphereNetwork/Agent-NN",
+  "homepage": "https://github.com/EcoSphereNetwork/Agent-NN",
+  "license": "MIT"
 }

--- a/tools/generate_flowise_plugin.py
+++ b/tools/generate_flowise_plugin.py
@@ -55,6 +55,9 @@ def generate_manifest(node_dir: Path, out_file: Path) -> Path:
         "nodes": collect_nodes(node_dir),
         "author": "Agent-NN Team",
         "keywords": ["agent-nn", "flowise", "plugin"],
+        "repository": "https://github.com/EcoSphereNetwork/Agent-NN",
+        "homepage": "https://github.com/EcoSphereNetwork/Agent-NN",
+        "license": "MIT",
     }
     out_file.write_text(json.dumps(manifest, indent=2))
     Path("plugin_version.txt").write_text(version)

--- a/tools/validate_plugin_manifest.py
+++ b/tools/validate_plugin_manifest.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""Validate flowise-plugin.json against a schema."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+
+SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "version": {"type": "string"},
+        "description": {"type": "string"},
+        "author": {"type": "string"},
+        "repository": {"type": "string"},
+        "homepage": {"type": "string"},
+        "license": {"type": "string"},
+        "keywords": {"type": "array", "items": {"type": "string"}},
+        "nodes": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+    },
+    "required": [
+        "name",
+        "version",
+        "description",
+        "author",
+        "repository",
+        "homepage",
+        "license",
+        "keywords",
+        "nodes",
+    ],
+}
+
+
+def validate_manifest(path: Path) -> None:
+    data = json.loads(path.read_text())
+    validator = Draft7Validator(SCHEMA)
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    if errors:
+        for err in errors:
+            loc = "/".join(str(p) for p in err.path) or "manifest"
+            print(f"{loc}: {err.message}")
+        raise SystemExit(1)
+    print("Manifest valid")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate flowise-plugin.json")
+    parser.add_argument("manifest", type=Path, nargs="?", default=Path("flowise-plugin.json"))
+    args = parser.parse_args()
+    validate_manifest(args.manifest)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- extend `flowise-plugin.json` with repository, homepage and license
- update generator script accordingly
- add manifest validator for FlowiseHub schema
- document the publishing workflow in `docs/flowisehub_publish.md`
- link main docs from `README.plugin.md`

## Testing
- `./tests/ci_check.sh` *(fails: pytest missing --cov plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6866bf9bab648324a2b0c412e1fad889