### PR TITLE
Implement MCP server and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ direkt in Flowise importiert werden.
 curl http://localhost:8000/agents/demo?format=flowise
 ```
 
+## MCP Server
+
+Der integrierte MCP-Server stellt unter `/v1/mcp/*` eine kompatible Schnittstelle für externe Dienste bereit. Die Python-Klasse `agentnn.mcp.MCPClient` ermöglicht das Senden von Aufgaben und Kontextdaten. Weitere Informationen finden sich in [docs/mcp.md](docs/mcp.md).
+
+
 ## Tests & Beiträge
 
 Bevor du einen Pull Request erstellst, führe bitte `ruff`, `mypy` und `pytest` aus. Details zum Entwicklungsprozess findest du in [CONTRIBUTING.md](CONTRIBUTING.md) sowie im Dokument [docs/test_strategy.md](docs/test_strategy.md). Sollten Module fehlen, können lokale Wheels oder ein internes Paketmirror verwendet werden.

--- a/agentnn/config.yml
+++ b/agentnn/config.yml
@@ -1,0 +1,4 @@
+mcp:
+  enabled: false
+  endpoint: "http://localhost:9000"
+  mode: "server"

--- a/agentnn/mcp/__init__.py
+++ b/agentnn/mcp/__init__.py
@@ -1,0 +1,7 @@
+"""MCP integration modules for Agent-NN."""
+
+from .mcp_client import MCPClient
+from .mcp_server import create_app
+from .context_adapter import to_mcp, from_mcp
+
+__all__ = ["MCPClient", "create_app", "to_mcp", "from_mcp"]

--- a/agentnn/mcp/context_adapter.py
+++ b/agentnn/mcp/context_adapter.py
@@ -1,0 +1,16 @@
+"""Utility functions to convert between Agent-NN ``ModelContext`` objects and
+Model Context Protocol (MCP) compatible dictionaries."""
+
+from __future__ import annotations
+
+from core.model_context import ModelContext
+
+
+def to_mcp(ctx: ModelContext) -> dict:
+    """Return a plain dictionary representation for MCP payloads."""
+    return ctx.model_dump()
+
+
+def from_mcp(data: dict) -> ModelContext:
+    """Create a :class:`ModelContext` instance from MCP payload data."""
+    return ModelContext(**data)

--- a/agentnn/mcp/mcp_client.py
+++ b/agentnn/mcp/mcp_client.py
@@ -1,0 +1,37 @@
+"""HTTP client wrapper for MCP compatible services."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import httpx
+
+from core.model_context import ModelContext
+
+from .context_adapter import from_mcp, to_mcp
+
+
+class MCPClient:
+    """Simple MCP client for executing tasks and managing context."""
+
+    def __init__(self, endpoint: str = "http://localhost:9000") -> None:
+        self._client = httpx.Client(base_url=endpoint.rstrip("/"))
+
+    def execute(self, ctx: ModelContext) -> ModelContext:
+        """Dispatch a context to an MCP server and return the updated context."""
+        resp = self._client.post("/v1/mcp/execute", json=to_mcp(ctx))
+        resp.raise_for_status()
+        return from_mcp(resp.json())
+
+    def update_context(self, ctx: ModelContext) -> dict[str, Any]:
+        """Store context information at the MCP server."""
+        resp = self._client.post("/v1/mcp/context", json=to_mcp(ctx))
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_context(self, session_id: str) -> List[ModelContext]:
+        """Fetch all contexts for a given session."""
+        resp = self._client.get(f"/v1/mcp/context/{session_id}")
+        resp.raise_for_status()
+        data = resp.json().get("context", [])
+        return [from_mcp(item) for item in data]

--- a/agentnn/mcp/mcp_server.py
+++ b/agentnn/mcp/mcp_server.py
@@ -1,0 +1,52 @@
+"""Lightweight MCP compatible server exposing context and execution endpoints."""
+
+from __future__ import annotations
+
+import os
+from fastapi import APIRouter, FastAPI
+
+from api_gateway.connectors import ServiceConnector
+from core.model_context import ModelContext
+from core.run_service import run_service
+
+DISPATCHER_URL = os.getenv("DISPATCHER_URL", "http://task_dispatcher:8000")
+SESSION_MANAGER_URL = os.getenv("SESSION_MANAGER_URL", "http://session_manager:8000")
+
+
+def create_app() -> FastAPI:
+    """Return the FastAPI application."""
+    router = APIRouter(prefix="/v1/mcp")
+    dispatcher = ServiceConnector(DISPATCHER_URL)
+    sessions = ServiceConnector(SESSION_MANAGER_URL)
+
+    @router.get("/ping")
+    async def ping() -> dict:
+        return {"status": "ok"}
+
+    @router.post("/execute", response_model=ModelContext)
+    async def execute(ctx: ModelContext) -> ModelContext:
+        return await dispatcher.post("/dispatch", ctx.model_dump())
+
+    @router.post("/context")
+    async def update_context(ctx: ModelContext) -> dict:
+        await sessions.post("/update_context", ctx.model_dump())
+        return {"status": "ok"}
+
+    @router.get("/context/{sid}")
+    async def get_context(sid: str) -> dict:
+        return await sessions.get(f"/context/{sid}")
+
+    app = FastAPI(title="Agent-NN MCP Server")
+    app.include_router(router)
+    return app
+
+
+def main() -> None:  # pragma: no cover - entrypoint
+    app = create_app()
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8090"))
+    run_service(app, host=host, port=port)
+
+
+if __name__ == "__main__":  # pragma: no cover - script
+    main()

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,33 @@
+# Model Context Protocol Integration
+
+Agent-NN exposes a minimal implementation of the **Model Context Protocol (MCP)**
+to exchange context information with third party services. The MCP server is
+implemented in `agentnn.mcp.mcp_server` and provides the following endpoints:
+
+- `GET /v1/mcp/ping` – health check
+- `POST /v1/mcp/execute` – dispatch a `ModelContext` to the internal task
+  dispatcher and return the result
+- `POST /v1/mcp/context` – store a context in the session manager
+- `GET /v1/mcp/context/{session_id}` – retrieve all contexts for a session
+
+A lightweight client wrapper is available via `agentnn.mcp.MCPClient`.
+
+Configure the MCP integration using `agentnn/config.yml`:
+
+```yaml
+mcp:
+  enabled: true
+  endpoint: "http://localhost:9000"
+  mode: "server"
+```
+
+When enabled, external tools can interact with Agent‑NN using the official MCP
+schemas. See the official specification for further details.
+
+Example request using ``curl``:
+
+```bash
+curl -X POST http://localhost:9000/v1/mcp/execute \
+     -H "Content-Type: application/json" \
+     -d '{"task_context": {"task_type": "chat", "description": "Hello"}}'
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
     - Worker Agents: components/worker-agents.md
     - Neural Models: components/neural-models.md
     - Vector Store: components/vector-store.md
+    - MCP Server: mcp.md
     - Federation Manager: architecture/federation.md
   - Advanced Features:
     - Security: advanced/security.md

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -1,0 +1,40 @@
+from fastapi.testclient import TestClient
+import importlib.util
+import pathlib
+
+spec = importlib.util.spec_from_file_location(
+    "mcp_server", pathlib.Path("agentnn/mcp/mcp_server.py")
+)
+mcp_server = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mcp_server)  # type: ignore
+
+
+class DummyConnector:
+    def __init__(self, *_: object, **__: object) -> None:
+        pass
+
+    async def post(self, path: str, json: dict) -> dict:
+        return {"echo": path, **json}
+
+    async def get(self, path: str) -> dict:
+        return {"path": path, "context": []}
+
+
+def test_execute_roundtrip(monkeypatch):
+    monkeypatch.setattr(mcp_server, "ServiceConnector", DummyConnector)
+    app = mcp_server.create_app()
+    client = TestClient(app)
+
+    ctx = {"task": "demo"}
+    resp = client.post("/v1/mcp/execute", json=ctx)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["echo"] == "/dispatch"
+
+    resp = client.post("/v1/mcp/context", json=ctx)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+    resp = client.get("/v1/mcp/context/123")
+    assert resp.status_code == 200
+    assert resp.json()["path"] == "/context/123"


### PR DESCRIPTION
## Summary
- add minimal MCP server with `/v1/mcp/*` routes
- provide MCP client and context adapter
- document MCP integration and update nav
- add basic integration test

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest tests/integration/test_mcp_server.py -q`
- `tests/ci_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6866c234e168832480308f3b11c72cb6