### PR TITLE
Iteration 14 MCP extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,14 @@ curl http://localhost:8000/agents/demo?format=flowise
 
 ## MCP Server
 
-Der integrierte MCP-Server stellt unter `/v1/mcp/*` eine kompatible Schnittstelle für externe Dienste bereit. Die Python-Klasse `agentnn.mcp.MCPClient` ermöglicht das Senden von Aufgaben und Kontextdaten. Weitere Informationen finden sich in [docs/mcp.md](docs/mcp.md).
+Der integrierte MCP-Server stellt unter `/v1/mcp/*` eine kompatible Schnittstelle für externe Dienste bereit. Die Python-Klasse `agentnn.mcp.MCPClient` ermöglicht das Senden von Aufgaben und Kontextdaten. Weitere Informationen finden sich in [docs/mcp.md](docs/mcp.md). Wichtige Endpunkte:
+
+- `POST /v1/mcp/execute` – Dispatch von Aufgaben
+- `POST /v1/mcp/task/execute` – Alias zu `/execute`
+- `POST /v1/mcp/agent/create` – Registrierung neuer Agenten
+- `POST /v1/mcp/tool/use` – Aufruf eines Plugin-Tools
+- `POST /v1/mcp/context` – Kontext speichern
+- `GET /v1/mcp/context/{session_id}` – Kontext abrufen
 
 
 ## Tests & Beiträge

--- a/agentnn/mcp/context_adapter.py
+++ b/agentnn/mcp/context_adapter.py
@@ -8,9 +8,11 @@ from core.model_context import ModelContext
 
 def to_mcp(ctx: ModelContext) -> dict:
     """Return a plain dictionary representation for MCP payloads."""
-    return ctx.model_dump()
+    return ctx.model_dump(exclude_none=True)
 
 
-def from_mcp(data: dict) -> ModelContext:
+def from_mcp(data: dict | ModelContext) -> ModelContext:
     """Create a :class:`ModelContext` instance from MCP payload data."""
-    return ModelContext(**data)
+    if isinstance(data, ModelContext):
+        return data
+    return ModelContext.model_validate(data)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -7,8 +7,13 @@ implemented in `agentnn.mcp.mcp_server` and provides the following endpoints:
 - `GET /v1/mcp/ping` – health check
 - `POST /v1/mcp/execute` – dispatch a `ModelContext` to the internal task
   dispatcher and return the result
+- `POST /v1/mcp/task/execute` – convenience alias for `/execute`
+- `POST /v1/mcp/agent/create` – register a new worker agent
+- `POST /v1/mcp/tool/use` – invoke a plugin tool
 - `POST /v1/mcp/context` – store a context in the session manager
+- `POST /v1/mcp/context/save` – convenience alias for `/context`
 - `GET /v1/mcp/context/{session_id}` – retrieve all contexts for a session
+- `GET /v1/mcp/context/get/{session_id}` – convenience alias for `/context/{session_id}`
 
 A lightweight client wrapper is available via `agentnn.mcp.MCPClient`.
 

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -20,6 +20,10 @@ class DummyConnector:
         return {"path": path, "context": []}
 
 
+import pytest
+
+
+@pytest.mark.unit
 def test_execute_roundtrip(monkeypatch):
     monkeypatch.setattr(mcp_server, "ServiceConnector", DummyConnector)
     app = mcp_server.create_app()
@@ -38,3 +42,35 @@ def test_execute_roundtrip(monkeypatch):
     resp = client.get("/v1/mcp/context/123")
     assert resp.status_code == 200
     assert resp.json()["path"] == "/context/123"
+
+
+@pytest.mark.unit
+def test_extended_routes(monkeypatch):
+    monkeypatch.setattr(mcp_server, "ServiceConnector", DummyConnector)
+    app = mcp_server.create_app()
+    client = TestClient(app)
+
+    ctx = {"task": "demo"}
+    resp = client.post("/v1/mcp/task/execute", json=ctx)
+    assert resp.status_code == 200
+    assert resp.json()["echo"] == "/dispatch"
+
+    resp = client.post("/v1/mcp/context/save", json=ctx)
+    assert resp.status_code == 200
+
+    resp = client.get("/v1/mcp/context/get/42")
+    assert resp.status_code == 200
+    assert resp.json()["path"] == "/context/42"
+
+    resp = client.post("/v1/mcp/agent/create", json={"name": "demo"})
+    assert resp.status_code == 200
+    assert resp.json()["echo"] == "/register"
+
+    resp = client.post(
+        "/v1/mcp/tool/use",
+        json={"tool_name": "t", "input": {}, "context": {}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["echo"] == "/execute_tool"
+
+


### PR DESCRIPTION
## Summary
- extend MCP context adapter
- expose additional endpoints on the MCP server
- document new RPC routes for MCP
- cover MCP server with unit tests
- refactor MCP endpoint aliases and update docs

## Testing
- `ruff check .`
- `mypy agentnn/mcp tests/integration/test_mcp_server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866c600bb6083249467ee76a2472ba9