### PR TITLE
Implement persistence and gateway

### DIFF
--- a/agentnn/auth/auth_middleware.py
+++ b/agentnn/auth/auth_middleware.py
@@ -1,0 +1,32 @@
+"""Simple header based authentication middleware."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import HTTPException, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Validate API key or bearer token from request headers."""
+
+    def __init__(self, app, api_keys: str = "", bearer_token: str | None = None) -> None:
+        super().__init__(app)
+        self.keys: List[str] = [k.strip() for k in api_keys.split(",") if k.strip()]
+        self.bearer = bearer_token
+
+    async def dispatch(self, request: Request, call_next):
+        authorized = False
+        key = request.headers.get("X-API-Key")
+        if key and (not self.keys or key in self.keys):
+            authorized = True
+        token = request.headers.get("Authorization")
+        if token and token.startswith("Bearer ") and self.bearer:
+            if token.split()[1] == self.bearer:
+                authorized = True
+        if not self.keys and not self.bearer:
+            authorized = True
+        if not authorized:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        return await call_next(request)

--- a/agentnn/mcp/mcp_gateway.py
+++ b/agentnn/mcp/mcp_gateway.py
@@ -1,0 +1,53 @@
+"""Public MCP gateway with authentication."""
+
+from __future__ import annotations
+
+import os
+from fastapi import FastAPI, Request
+
+from api_gateway.connectors import ServiceConnector
+from core.run_service import run_service
+from ..auth.auth_middleware import AuthMiddleware
+
+MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://localhost:8090")
+API_KEYS = os.getenv("MCP_API_KEYS", "")
+BEARER_TOKEN = os.getenv("MCP_BEARER_TOKEN")
+
+
+def create_gateway() -> FastAPI:
+    app = FastAPI(title="MCP Gateway")
+    app.add_middleware(AuthMiddleware, api_keys=API_KEYS, bearer_token=BEARER_TOKEN)
+    conn = ServiceConnector(MCP_SERVER_URL)
+    prefix = "/v1/mcp"
+
+    @app.post(f"{prefix}/task/execute")
+    async def execute(request: Request) -> dict:
+        payload = await request.json()
+        return await conn.post("/execute", payload)
+
+    @app.post(f"{prefix}/tool/use")
+    async def tool_use(request: Request) -> dict:
+        payload = await request.json()
+        return await conn.post("/tool/use", payload)
+
+    @app.post(f"{prefix}/context/save")
+    async def save(request: Request) -> dict:
+        payload = await request.json()
+        return await conn.post("/context/save", payload)
+
+    @app.get(f"{prefix}/context/load/{'{sid}'}")
+    async def load(sid: str) -> dict:
+        return await conn.get(f"/context/load/{sid}")
+
+    return app
+
+
+def main() -> None:  # pragma: no cover - entrypoint
+    app = create_gateway()
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8089"))
+    run_service(app, host=host, port=port)
+
+
+if __name__ == "__main__":  # pragma: no cover - script
+    main()

--- a/agentnn/storage/context_store.py
+++ b/agentnn/storage/context_store.py
@@ -1,0 +1,64 @@
+"""Persistent context storage using SQLite or Redis."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from typing import Dict, List
+
+try:
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    redis = None
+
+__all__ = ["save_context", "load_context", "list_contexts"]
+
+_BACKEND = os.getenv("CONTEXT_BACKEND", "sqlite").lower()
+_DB_PATH = os.getenv("CONTEXT_DB_PATH", "data/context.db")
+_REDIS_URL = os.getenv("CONTEXT_REDIS_URL", "redis://localhost:6379/0")
+
+if _BACKEND == "redis" and redis is not None:
+    _client = redis.Redis.from_url(_REDIS_URL)
+    _backend = "redis"
+else:
+    os.makedirs(os.path.dirname(_DB_PATH), exist_ok=True)
+    _conn = sqlite3.connect(_DB_PATH, check_same_thread=False)
+    _conn.execute(
+        "CREATE TABLE IF NOT EXISTS contexts (session_id TEXT, ts REAL, data TEXT)"
+    )
+    _backend = "sqlite"
+
+
+def save_context(session_id: str, ctx: Dict) -> None:
+    """Persist a context for the given session."""
+    payload = json.dumps(ctx)
+    ts = time.time()
+    if _backend == "redis":
+        _client.rpush(f"ctx:{session_id}", payload)
+    else:
+        _conn.execute(
+            "INSERT INTO contexts VALUES (?, ?, ?)", (session_id, ts, payload)
+        )
+        _conn.commit()
+
+
+def load_context(session_id: str) -> List[Dict]:
+    """Return stored contexts for a session."""
+    if _backend == "redis":
+        items = _client.lrange(f"ctx:{session_id}", 0, -1)
+        return [json.loads(x) for x in items]
+    rows = _conn.execute(
+        "SELECT data FROM contexts WHERE session_id=? ORDER BY ts", (session_id,)
+    ).fetchall()
+    return [json.loads(r[0]) for r in rows]
+
+
+def list_contexts() -> List[str]:
+    """Return list of session ids that have stored contexts."""
+    if _backend == "redis":
+        keys = _client.keys("ctx:*")
+        return [k.decode("utf-8")[4:] for k in keys]
+    rows = _conn.execute("SELECT DISTINCT session_id FROM contexts").fetchall()
+    return [r[0] for r in rows]

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -11,9 +11,11 @@ implemented in `agentnn.mcp.mcp_server` and provides the following endpoints:
 - `POST /v1/mcp/agent/create` – register a new worker agent
 - `POST /v1/mcp/tool/use` – invoke a plugin tool
 - `POST /v1/mcp/context` – store a context in the session manager
-- `POST /v1/mcp/context/save` – alias for `/context`
+- `POST /v1/mcp/context/save` – persist a context entry
 - `GET /v1/mcp/context/{session_id}` – retrieve all contexts for a session
 - `GET /v1/mcp/context/get/{session_id}` – alias for `/context/{session_id}`
+- `GET /v1/mcp/context/load/{session_id}` – load persisted contexts
+- `GET /v1/mcp/context/history` – list sessions with stored context
 
 A lightweight client wrapper is available via `agentnn.mcp.MCPClient`.
 

--- a/docs/security/mcp_security.md
+++ b/docs/security/mcp_security.md
@@ -1,0 +1,19 @@
+# MCP Server Security
+
+The MCP server can optionally protect its routes with API keys or bearer tokens.
+Set the environment variables `MCP_API_KEYS` (comma separated) or
+`MCP_BEARER_TOKEN` to enable the check. When no values are provided all requests
+are accepted.
+
+Example using an API key:
+
+```bash
+export MCP_API_KEYS="secret123"
+curl -X POST http://localhost:8089/v1/mcp/task/execute \
+     -H "X-API-Key: secret123" \
+     -H "Content-Type: application/json" \
+     -d '{"task_context": {"task_type": "ping"}}'
+```
+
+Clients may alternatively use `Authorization: Bearer <token>` if
+`MCP_BEARER_TOKEN` is configured.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,8 @@ nav:
     - MCP Server: mcp.md
     - Federation Manager: architecture/federation.md
   - Advanced Features:
-    - Security: advanced/security.md
+    - Security: security/authentication.md
+    - MCP Gateway Security: security/mcp_security.md
     - Evaluation: advanced/evaluation.md
     - Monitoring: advanced/monitoring.md
     - Scaling: advanced/scaling.md

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -58,6 +58,12 @@ def test_extended_routes(monkeypatch):
     resp = client.post("/v1/mcp/context/save", json=ctx)
     assert resp.status_code == 200
 
+    resp = client.get("/v1/mcp/context/load/sid1")
+    assert resp.status_code == 200
+
+    resp = client.get("/v1/mcp/context/history")
+    assert resp.status_code == 200
+
     resp = client.get("/v1/mcp/context/get/42")
     assert resp.status_code == 200
     assert resp.json()["path"] == "/context/42"

--- a/tests/storage/test_context_store_sqlite.py
+++ b/tests/storage/test_context_store_sqlite.py
@@ -1,0 +1,20 @@
+import importlib.util
+import pathlib
+import pytest
+
+
+@pytest.mark.unit
+def test_context_store_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("CONTEXT_BACKEND", "sqlite")
+    monkeypatch.setenv("CONTEXT_DB_PATH", str(tmp_path / "ctx.db"))
+    spec = importlib.util.spec_from_file_location(
+        "context_store", pathlib.Path("agentnn/storage/context_store.py")
+    )
+    store = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(store)  # type: ignore
+    store.save_context("s1", {"a": 1})
+    store.save_context("s1", {"b": 2})
+    items = store.load_context("s1")
+    assert items[0]["a"] == 1
+    assert items[1]["b"] == 2
+    assert "s1" in store.list_contexts()


### PR DESCRIPTION
## Summary
- add context store with SQLite or Redis backend
- secure routes via new `AuthMiddleware`
- expose limited MCP routes through a gateway
- document security setup and update MCP docs
- test context store persistence

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest`
- `pytest -q tests/storage/test_context_store_sqlite.py`

------
https://chatgpt.com/codex/tasks/task_e_6866ce6fc5d08324903ecf7995f45e0c