### PR TITLE
Implement role-aware sessions and snapshots

### DIFF
--- a/agentnn/prompting/prompt_refiner.py
+++ b/agentnn/prompting/prompt_refiner.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 __all__ = ["propose_refinement", "evaluate_prompt_quality"]
+
 
 def propose_refinement(prompt: str, strategy: str = "direct") -> str:
     """Return an improved version of the given prompt.

--- a/agentnn/storage/snapshot_store.py
+++ b/agentnn/storage/snapshot_store.py
@@ -1,0 +1,40 @@
+"""Session snapshot utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Dict
+
+from . import context_store
+
+_BASE_PATH = Path(os.getenv("SNAPSHOT_PATH", "data/snapshots"))
+
+
+def save_snapshot(session_id: str, session_data: Dict[str, Any] | None = None) -> str:
+    """Persist context and metadata for ``session_id`` and return snapshot id."""
+    _BASE_PATH.mkdir(parents=True, exist_ok=True)
+    snapshot_id = str(uuid.uuid4())
+    data = {
+        "session_id": session_id,
+        "context": context_store.load_context(session_id),
+        "session": session_data or {},
+    }
+    with open(_BASE_PATH / f"{snapshot_id}.json", "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    return snapshot_id
+
+
+def restore_snapshot(snapshot_id: str) -> str:
+    """Restore snapshot and return new session id with loaded context."""
+    path = _BASE_PATH / f"{snapshot_id}.json"
+    if not path.exists():
+        raise FileNotFoundError(snapshot_id)
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    new_session = str(uuid.uuid4())
+    for ctx in data.get("context", []):
+        context_store.save_context(new_session, ctx)
+    return new_session

--- a/cli/session_runner.py
+++ b/cli/session_runner.py
@@ -1,0 +1,86 @@
+"""Interactive CLI for running Agent-NN sessions."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Optional
+
+import typer
+import yaml
+
+from agentnn.reasoning.context_reasoner import MajorityVoteReasoner
+from agentnn.session.session_manager import SessionManager
+from agentnn.storage import snapshot_store
+
+app = typer.Typer(help="Run and observe live agent sessions")
+manager = SessionManager()
+
+
+@app.command()
+def start(template: Optional[Path] = None) -> None:
+    """Start a new session from optional YAML template."""
+    sid = manager.create_session()
+    if template and template.exists():
+        data = yaml.safe_load(template.read_text())
+        for agent in data.get("agents", []):
+            manager.add_agent(
+                sid,
+                agent["id"],
+                role=agent.get("role"),
+                priority=agent.get("priority", 1),
+                exclusive=agent.get("exclusive", False),
+            )
+        for task in data.get("tasks", []):
+            manager.run_task(sid, task)
+    typer.echo(json.dumps({"session_id": sid}))
+
+
+@app.command()
+def watch(session_id: str) -> None:
+    """Print message history for a session."""
+    session = manager.get_session(session_id)
+    typer.echo(json.dumps(session.get("message_history", []), indent=2))
+
+
+@app.command()
+def vote(session_id: str, roles: str = "") -> None:
+    """Aggregate last step results using majority vote."""
+    session = manager.get_session(session_id)
+    reasoner = MajorityVoteReasoner(
+        [r.strip() for r in roles.split(",") if r.strip()] or None
+    )
+    for entry in session.get("message_history", []):
+        reasoner.add_step(
+            entry["agent"],
+            entry.get("result"),
+            role=entry.get("role"),
+        )
+    typer.echo(json.dumps({"decision": reasoner.decide()}))
+
+
+@app.command()
+def refine(session_id: str, message: str) -> None:
+    """Run another task with all agents."""
+    manager.run_task(session_id, message)
+    typer.echo("ok")
+
+
+@app.command()
+def snapshot(session_id: str) -> None:
+    """Save snapshot of session state."""
+    session = manager.get_session(session_id) or {}
+    snap = snapshot_store.save_snapshot(session_id, session)
+    typer.echo(json.dumps({"snapshot_id": snap}))
+
+
+@app.command()
+def restore(snapshot_id: str) -> None:
+    """Restore a snapshot and return new session id."""
+    sid = snapshot_store.restore_snapshot(snapshot_id)
+    typer.echo(json.dumps({"session_id": sid}))
+
+
+if __name__ == "__main__":
+    app()

--- a/core/model_context.py
+++ b/core/model_context.py
@@ -38,6 +38,8 @@ class AgentRunContext(BaseModel):
     score: Optional[float] = None
     feedback: Optional[str] = None
     voted_by: List[str] = []
+    priority: int | None = None
+    exclusive: bool = False
 
 
 class ModelContext(BaseModel):

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,13 @@
+# Session Runner CLI
+
+The `session_runner.py` tool simplifies starting and observing agent sessions.
+
+```
+python cli/session_runner.py start examples/three_agent_chain.yaml
+python cli/session_runner.py watch <session_id>
+python cli/session_runner.py vote <session_id> --roles critic,reviewer
+python cli/session_runner.py snapshot <session_id>
+```
+
+Sessions defined in a YAML template consist of an `agents` list and a sequence of
+`tasks`. The tool prints results as JSON for easy scripting.

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -1,0 +1,13 @@
+# Agent Roles
+
+Agent-NN uses simple role labels to control agent behaviour. Every agent profile
+specifies a `role` such as `writer`, `critic` or `retriever`.
+
+The session manager attaches agents with a role and an optional priority. The
+reasoner can limit voting to selected roles so that, for example, only critics
+may approve a result.
+
+Additional flags:
+
+- **priority** – smaller numbers are executed first
+- **exclusive** – if set, only this agent contributes to the decision

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -1,0 +1,12 @@
+# Session Snapshots
+
+Snapshots store the full conversation context and metadata for a session. They
+can be created at any time and restored later to reproduce a run.
+
+```
+from agentnn.storage import snapshot_store
+snap_id = snapshot_store.save_snapshot(session_id)
+new_session = snapshot_store.restore_snapshot(snap_id)
+```
+
+Snapshots are saved as JSON files under `data/snapshots/`.

--- a/tests/storage/test_snapshot_store.py
+++ b/tests/storage/test_snapshot_store.py
@@ -1,0 +1,24 @@
+import importlib.util
+import pathlib
+
+
+def test_snapshot_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("CONTEXT_BACKEND", "sqlite")
+    monkeypatch.setenv("CONTEXT_DB_PATH", str(tmp_path / "ctx.db"))
+    monkeypatch.setenv("SNAPSHOT_PATH", str(tmp_path))
+    ctx_spec = importlib.util.spec_from_file_location(
+        "context_store", pathlib.Path("agentnn/storage/context_store.py")
+    )
+    ctx = importlib.util.module_from_spec(ctx_spec)
+    ctx_spec.loader.exec_module(ctx)  # type: ignore
+    snap_spec = importlib.util.spec_from_file_location(
+        "snapshot_store", pathlib.Path("agentnn/storage/snapshot_store.py")
+    )
+    snap = importlib.util.module_from_spec(snap_spec)
+    snap_spec.loader.exec_module(snap)  # type: ignore
+
+    ctx.save_context("s1", {"a": 1})
+    snap_id = snap.save_snapshot("s1")
+    new_session = snap.restore_snapshot(snap_id)
+    items = ctx.load_context(new_session)
+    assert items[0]["a"] == 1


### PR DESCRIPTION
## Summary
- extend `AgentRunContext` with `priority` and `exclusive`
- add role-based filtering in `MajorityVoteReasoner`
- enrich `SessionManager` with role logic and execution order
- store and restore session snapshots
- provide `session_runner.py` CLI
- document roles, snapshots and CLI usage
- test snapshot store

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866d985d3d883248e095aed2742ef6e