### PR TITLE
Consolidate agentnn CLI

### DIFF
--- a/agentnn/__init__.py
+++ b/agentnn/__init__.py
@@ -1,5 +1,6 @@
 """Agent-NN package wrapper."""
 
+import sdk as sdk
 from sdk import *  # re-export sdk components  # noqa: F403,F401
 from sdk.__version__ import __version__
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,15 +1,34 @@
 # AgentNN CLI
 
-The command line interface is now fully modular. Each logical group of features
-is implemented as a subcommand under `sdk.cli.commands`.
+`agentnn` is the unified command line interface for all services of Agent‑NN.
+Install the project and run `agentnn --help` to see available commands.
 
-Common examples:
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `session` | manage and track conversation sessions |
+| `context` | export stored context data |
+| `agent` | inspect and update agent profiles |
+| `task` | queue and inspect tasks |
+| `model` | list and switch language models |
+| `config` | show effective configuration |
+| `governance` | governance and trust utilities |
+
+## Examples
 
 ```bash
-python -m sdk.cli session start examples/three_agent_chain.yaml
-python -m sdk.cli agent list
-python -m sdk.cli model list
+agentnn session start examples/demo.yaml
+agentnn context export mysession --out demo_context.json
+agentnn agent deploy --config config/agent.yaml
 ```
 
-Session templates consist of an `agents` list and a sequence of `tasks`.
-The tool prints results as JSON for easy scripting.
+## Global Flags
+
+- `--version` – show version and exit
+- `--token` – override API token for this call
+- `--help` – display help for any command
+
+Session templates are YAML files containing `agents` and `tasks` sections.
+The CLI prints JSON output so that results can easily be processed in scripts.
+Check file paths and YAML formatting if a command reports errors.

--- a/sdk/cli/__init__.py
+++ b/sdk/cli/__init__.py
@@ -1,0 +1,5 @@
+"""CLI helpers and command groups."""
+
+from ..__version__ import __version__
+
+__all__ = ["__version__"]

--- a/sdk/cli/client.py
+++ b/sdk/cli/client.py
@@ -1,0 +1,3 @@
+from ..client.agent_client import AgentClient
+
+__all__ = ["AgentClient"]

--- a/sdk/cli/commands/context.py
+++ b/sdk/cli/commands/context.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+
+from agentnn.storage import context_store
+from ..utils import print_success
+
+context_app = typer.Typer(name="context", help="Context utilities")
+
+
+@context_app.command("export")
+def export(session_id: str, out: Path) -> None:
+    """Export stored context for SESSION_ID to OUT."""
+    data = context_store.load_context(session_id)
+    out.write_text(json.dumps(data, indent=2))
+    print_success(f"written to {out}")
+
+
+__all__ = ["context_app"]

--- a/sdk/cli/commands/session.py
+++ b/sdk/cli/commands/session.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from typing import Optional
 
 import typer
-import yaml
+
+from ..utils import load_yaml, print_success
 
 from agentnn.reasoning.context_reasoner import MajorityVoteReasoner
 from agentnn.session.session_manager import SessionManager
@@ -19,7 +20,7 @@ def start(template: Optional[Path] = None) -> None:
     """Start a new session from optional YAML template."""
     sid = manager.create_session()
     if template and template.exists():
-        data = yaml.safe_load(template.read_text())
+        data = load_yaml(template)
         for agent in data.get("agents", []):
             manager.add_agent(
                 sid,
@@ -30,7 +31,7 @@ def start(template: Optional[Path] = None) -> None:
             )
         for task in data.get("tasks", []):
             manager.run_task(sid, task)
-    typer.echo(json.dumps({"session_id": sid}))
+    print_success(json.dumps({"session_id": sid}))
 
 
 @session_app.command("watch")

--- a/sdk/cli/main.py
+++ b/sdk/cli/main.py
@@ -12,6 +12,7 @@ from .commands.config_cmd import register as register_config
 from .commands.governance import register as register_governance
 from .commands.agentctl import register as register_agentctl
 from .commands.dispatch import register as register_dispatch
+from .commands.context import context_app
 
 app = typer.Typer()
 
@@ -21,6 +22,7 @@ app.add_typer(root_app)
 # sub command groups
 app.add_typer(session_app, name="session")
 app.add_typer(agent_app, name="agent")
+app.add_typer(context_app, name="context")
 register_tasks(app)
 register_model(app)
 register_config(app)

--- a/sdk/cli/utils.py
+++ b/sdk/cli/utils.py
@@ -1,5 +1,13 @@
-import typer
+"""Helper utilities for CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
 import httpx
+import typer
+import yaml
 
 
 def handle_http_error(err: httpx.HTTPStatusError) -> None:
@@ -12,3 +20,36 @@ def handle_http_error(err: httpx.HTTPStatusError) -> None:
     else:
         typer.secho(f"HTTP Error: {err.response.status_code}", fg=typer.colors.RED)
     raise typer.Exit(1)
+
+
+def print_success(msg: str) -> None:
+    """Print a success message in green."""
+
+    typer.secho(msg, fg=typer.colors.GREEN)
+
+
+def print_error(msg: str) -> None:
+    """Print an error message in red."""
+
+    typer.secho(msg, fg=typer.colors.RED)
+
+
+def load_yaml(path: Path) -> Dict[str, Any]:
+    """Return YAML contents of ``path`` as a dict."""
+
+    return yaml.safe_load(path.read_text())
+
+
+def confirm_action(prompt: str) -> bool:
+    """Ask the user to confirm an action."""
+
+    return typer.confirm(prompt)
+
+
+__all__ = [
+    "handle_http_error",
+    "print_success",
+    "print_error",
+    "load_yaml",
+    "confirm_action",
+]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "smolit=cli.smolit_cli:main",
+            "agentnn=sdk.cli.main:app",
         ],
     },
     author="OpenHands",

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -1,0 +1,107 @@
+from typer.testing import CliRunner
+
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault(
+    "mcp",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(BaseModel=object, Field=lambda *a, **k: None)
+    ),
+)
+
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+
+from sdk.cli.main import app
+
+
+def test_agentnn_help():
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "session" in result.stdout
+
+
+def test_session_start(monkeypatch, tmp_path):
+    from sdk.cli.commands import session as session_cmd
+
+    monkeypatch.setattr(session_cmd.manager, "create_session", lambda: "sid")
+    monkeypatch.setattr(session_cmd.manager, "add_agent", lambda *a, **k: None)
+    monkeypatch.setattr(session_cmd.manager, "run_task", lambda *a, **k: None)
+
+    tpl = tmp_path / "tpl.yaml"
+    tpl.write_text("agents: []\ntasks: []")
+    runner = CliRunner()
+    result = runner.invoke(app, ["session", "start", str(tpl)])
+    assert result.exit_code == 0
+    assert "sid" in result.stdout
+
+
+def test_session_snapshot(monkeypatch):
+    from sdk.cli.commands import session as session_cmd
+
+    monkeypatch.setattr(session_cmd.manager, "get_session", lambda sid: {})
+    monkeypatch.setattr(
+        session_cmd.snapshot_store, "save_snapshot", lambda sid, data: "snap"
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["session", "snapshot", "sid"])
+    assert result.exit_code == 0
+    assert "snap" in result.stdout
+
+
+def test_agent_deploy(monkeypatch, tmp_path):
+    from sdk.cli.commands import agentctl
+
+    monkeypatch.setattr(agentctl, "load_agent_file", lambda p: {"id": "demo"})
+
+    class DummyRegistry:
+        def __init__(self, endpoint: str) -> None:
+            pass
+
+        def deploy(self, data):
+            return {"ok": True}
+
+    monkeypatch.setattr(agentctl, "AgentRegistry", DummyRegistry)
+    cfg = tmp_path / "agent.yaml"
+    cfg.write_text("id: demo")
+    runner = CliRunner()
+    result = runner.invoke(app, ["agent", "deploy", str(cfg)])
+    assert result.exit_code == 0
+    assert "ok" in result.stdout
+
+
+def test_dispatch(monkeypatch):
+    from sdk.cli.commands import dispatch as dispatch_mod
+
+    class DummyClient:
+        def dispatch_task(self, ctx):
+            return {"ok": True}
+
+    monkeypatch.setattr(dispatch_mod, "AgentClient", lambda: DummyClient())
+    runner = CliRunner()
+    result = runner.invoke(app, ["task", "dispatch", "hello"])
+    assert result.exit_code == 0
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- expose SDK version in `sdk.cli` and add missing package init
- add helper functions to CLI utils
- allow exporting stored contexts via new `context` commands
- tweak session start to use `load_yaml`
- register context commands and update entry point script
- document usage of `agentnn` CLI
- add smoke tests for main commands
- update console script in setup

## Testing
- `ruff check sdk/cli tests/cli docs/cli.md setup.py agentnn/__init__.py`
- `mypy sdk/cli`
- `pytest tests/cli/test_cli_commands.py -q` *(fails: ImportError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866e7300fd0832492cf83343145b1ca