### PR TITLE
Backport legacy CLI functions

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,10 +8,11 @@ Install the project and run `agentnn --help` to see available commands.
 | Command | Description |
 |---------|-------------|
 | `session` | manage and track conversation sessions |
-| `context` | export stored context data |
+| `context` | export stored context data and context maps |
 | `agent` | inspect and update agent profiles |
 | `task` | queue and inspect tasks |
 | `model` | list and switch language models |
+| `prompt` | refine prompts and check quality |
 | `config` | show effective configuration |
 | `governance` | governance and trust utilities |
 
@@ -20,7 +21,7 @@ Install the project and run `agentnn --help` to see available commands.
 ```bash
 agentnn session start examples/demo.yaml
 agentnn context export mysession --out demo_context.json
-agentnn agent deploy --config config/agent.yaml
+agentnn agent register config/agent.yaml
 ```
 
 ## Global Flags
@@ -32,6 +33,17 @@ agentnn agent deploy --config config/agent.yaml
 Session templates are YAML files containing `agents` and `tasks` sections.
 The CLI prints JSON output so that results can easily be processed in scripts.
 Check file paths and YAML formatting if a command reports errors.
+
+## Alte CLI ersetzt
+
+Vor der Modularisierung gab es mehrere Einstiegspunkte wie `cli/agentctl.py`
+oder `mcp/cli.py`. Alle Funktionen wurden in `agentnn` konsolidiert. Beispiele
+zur Migration:
+
+```bash
+python cli/agentctl.py deploy config/agent.yaml  # alt
+agentnn agent register config/agent.yaml         # neu
+```
 
 ## 🧩 CLI-Architektur & Interna
 

--- a/sdk/cli/commands/agent.py
+++ b/sdk/cli/commands/agent.py
@@ -6,12 +6,14 @@ from datetime import datetime
 from dataclasses import asdict
 import os
 from typing import List
+from pathlib import Path
 
 import typer
 import httpx
 
 from ..utils import handle_http_error
 from ..client import AgentClient
+from agentnn.deployment.agent_registry import AgentRegistry, load_agent_file
 from core.agent_profile import PROFILE_DIR, AgentIdentity
 from core.agent_evolution import evolve_profile
 from core.crypto import generate_keypair
@@ -46,12 +48,27 @@ def agents() -> None:
     typer.echo(json.dumps(result, indent=2))
 
 
+@agent_app.command("register")
+def agent_register(config: Path, endpoint: str = "http://localhost:8090") -> None:
+    """Register an agent configuration with the registry."""
+    data = load_agent_file(config)
+    registry = AgentRegistry(endpoint)
+    result = registry.deploy(data)
+    typer.echo(json.dumps(result, indent=2))
+
+
 @agent_app.command("profile")
 def agent_profile(name: str) -> None:
     """Show profile information for an agent."""
     client = AgentClient()
     result = client.get_agent_profile(name)
     typer.echo(json.dumps(result, indent=2))
+
+
+@agent_app.command("info")
+def agent_info(name: str) -> None:
+    """Alias for ``profile``."""
+    agent_profile(name)
 
 
 @agent_app.command("update")

--- a/sdk/cli/commands/context.py
+++ b/sdk/cli/commands/context.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import typer
 
 from agentnn.storage import context_store
+from agentnn.context import context_map
 from ..utils.formatting import print_success
 
 context_app = typer.Typer(name="context", help="Context utilities")
@@ -16,6 +17,24 @@ def export(session_id: str, out: Path) -> None:
     """Export stored context for SESSION_ID to OUT."""
     data = context_store.load_context(session_id)
     out.write_text(json.dumps(data, indent=2))
+    print_success(f"written to {out}")
+
+
+@context_app.command("map")
+def map_json(out: Path | None = None) -> None:
+    """Generate a context map as JSON."""
+    data = context_map.generate_map()
+    if out:
+        out.write_text(json.dumps(data, indent=2))
+        print_success(f"written to {out}")
+    else:
+        typer.echo(json.dumps(data, indent=2))
+
+
+@context_app.command("map-html")
+def map_html(out: Path) -> None:
+    """Generate a context map as interactive HTML."""
+    context_map.export_html(out)
     print_success(f"written to {out}")
 
 

--- a/sdk/cli/commands/prompt.py
+++ b/sdk/cli/commands/prompt.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import typer
+
+from agentnn.prompting import propose_refinement, evaluate_prompt_quality
+
+prompt_app = typer.Typer(name="prompt", help="Prompt utilities")
+
+
+@prompt_app.command("refine")
+def refine_prompt(input: str, strategy: str = typer.Option("direct", "--strategy")) -> None:
+    """Return a refined prompt string."""
+    typer.echo(propose_refinement(input, strategy))
+
+
+@prompt_app.command("quality")
+def quality_prompt(input: str) -> None:
+    """Evaluate quality of INPUT and output score."""
+    score = evaluate_prompt_quality(input)
+    typer.echo(str(score))
+
+
+__all__ = ["prompt_app"]

--- a/sdk/cli/commands/session.py
+++ b/sdk/cli/commands/session.py
@@ -80,6 +80,14 @@ def restore(snapshot_id: str) -> None:
     typer.echo(json.dumps({"session_id": sid}))
 
 
+@session_app.command("list")
+def session_list() -> None:
+    """List active sessions."""
+    client = AgentClient()
+    data = client.list_sessions()
+    typer.echo(json.dumps(data, indent=2))
+
+
 @session_app.command("budget")
 def session_budget(session_id: str) -> None:
     """Show consumed tokens for a session."""

--- a/sdk/cli/main.py
+++ b/sdk/cli/main.py
@@ -13,6 +13,7 @@ from .commands.governance import register as register_governance
 from .commands.agentctl import register as register_agentctl
 from .commands.dispatch import register as register_dispatch
 from .commands.context import context_app
+from .commands.prompt import prompt_app
 
 app = typer.Typer()
 
@@ -23,6 +24,7 @@ app.add_typer(root_app)
 app.add_typer(session_app, name="session")
 app.add_typer(agent_app, name="agent")
 app.add_typer(context_app, name="context")
+app.add_typer(prompt_app, name="prompt")
 register_tasks(app)
 register_model(app)
 register_config(app)

--- a/tests/cli/test_legacy_equivalence.py
+++ b/tests/cli/test_legacy_equivalence.py
@@ -1,0 +1,90 @@
+from typer.testing import CliRunner
+
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault(
+    "mcp",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(BaseModel=object, Field=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+
+sys.modules.setdefault(
+    "agentnn.session.session_manager",
+    types.SimpleNamespace(SessionManager=object),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_ws", types.SimpleNamespace(ws_server=types.SimpleNamespace(broadcast=lambda *a, **k: None))
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_server", types.SimpleNamespace(create_app=lambda: None)
+)
+import sdk.nn_models as _nn
+sys.modules.setdefault("sdk.cli.nn_models", _nn)
+DummySettings = type(
+    "DummySettings",
+    (),
+    {"load": classmethod(lambda cls: cls()), "__init__": lambda self: None},
+)
+sys.modules.setdefault("sdk.cli.config", types.SimpleNamespace(SDKSettings=DummySettings))
+sys.modules.setdefault(
+    "core.config", types.SimpleNamespace(settings=types.SimpleNamespace(model_dump=lambda: {}))
+)
+
+from sdk.cli.main import app  # noqa: E402
+
+
+def test_agent_register_equiv(monkeypatch, tmp_path):
+    """New agent register behaves like legacy deploy."""
+    from sdk.cli.commands import agent as agent_cmd
+    from sdk.cli.commands import agentctl
+
+    cfg = tmp_path / "agent.yaml"
+    cfg.write_text("id: demo")
+
+    monkeypatch.setattr(agent_cmd, "load_agent_file", lambda p: {"id": "demo"})
+    monkeypatch.setattr(agentctl, "load_agent_file", lambda p: {"id": "demo"})
+
+    called = {}
+
+    class DummyRegistry:
+        def __init__(self, endpoint: str) -> None:
+            called["endpoint"] = endpoint
+
+        def deploy(self, data):
+            called["data"] = data
+            return {"ok": True}
+
+    monkeypatch.setattr(agent_cmd, "AgentRegistry", DummyRegistry)
+    monkeypatch.setattr(agentctl, "AgentRegistry", DummyRegistry)
+
+    runner = CliRunner()
+    result_new = runner.invoke(app, ["agent", "register", str(cfg)])
+    result_old = runner.invoke(app, ["agent", "deploy", str(cfg)])
+
+    assert result_new.exit_code == 0 and result_old.exit_code == 0
+    assert called.get("data") == {"id": "demo"}


### PR DESCRIPTION
## Summary
- add session list and context map commands
- expose agent register and info via agent group
- provide prompt utilities
- wire new commands into main app
- document updated usage
- check CLI commands via unit tests

## Testing
- `ruff check sdk/cli tests/cli`
- `mypy sdk/cli tests/cli`
- `pytest tests/cli/test_cli_commands.py tests/cli/test_legacy_equivalence.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6866efc3e9448324ae5fff5c0ab51ec8