### PR TITLE
Improve CLI UX with interactive wizard and output formats

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,6 +29,21 @@ agentnn agent register config/agent.yaml
 - `--version` – show version and exit
 - `--token` – override API token for this call
 - `--help` – display help for any command
+- `--verbose` – detailed log output
+- `--quiet` – suppress info messages
+- `--debug` – show stack traces on errors
+
+## \U0001F4C0 Ausgabeformate & interaktive Nutzung
+
+Viele `list`-Befehle unterstützen das Flag `--output` mit den Optionen
+`table`, `json` oder `markdown`.
+
+```bash
+agentnn agent list --output markdown
+```
+
+Der Befehl `agent register --interactive` startet einen kurzen Wizard und
+fragt Name, Rolle, Tools und Beschreibung interaktiv ab.
 
 Session templates are YAML files containing `agents` and `tasks` sections.
 The CLI prints JSON output so that results can easily be processed in scripts.

--- a/sdk/cli/commands/model.py
+++ b/sdk/cli/commands/model.py
@@ -8,16 +8,19 @@ import mlflow
 
 from ..client import AgentClient
 from ..nn_models import ModelManager
+from ..utils.formatting import print_output
 
 model_app = typer.Typer(name="model", help="Model management commands")
 
 
 @model_app.command("list")
-def model_list() -> None:
+def model_list(
+    output: str = typer.Option("table", "--output", help="table|json|markdown")
+) -> None:
     """List available models."""
     client = AgentClient()
-    models = client.get_models()
-    typer.echo(json.dumps(models, indent=2))
+    models = client.get_models().get("models", [])
+    print_output(models, output)
 
 
 @model_app.command("runs-view")

--- a/sdk/cli/commands/root.py
+++ b/sdk/cli/commands/root.py
@@ -24,6 +24,9 @@ def version_callback(
     ctx: typer.Context,
     version: bool = typer.Option(False, "--version", help="Show version and exit"),
     token: str = typer.Option(None, "--token", help="API token"),
+    verbose: bool = typer.Option(False, "--verbose", help="Enable verbose logging"),
+    quiet: bool = typer.Option(False, "--quiet", help="Suppress info output"),
+    debug: bool = typer.Option(False, "--debug", help="Show stack traces"),
 ) -> None:
     """Global options."""
     if version:
@@ -31,6 +34,14 @@ def version_callback(
         ctx.exit()
     if token:
         os.environ["AGENTNN_API_TOKEN"] = token
+    if debug:
+        os.environ["AGENTNN_DEBUG"] = "1"
+    level = "INFO"
+    if verbose:
+        level = "DEBUG"
+    if quiet:
+        level = "WARNING"
+    os.environ.setdefault("AGENTNN_LOG_LEVEL", level)
 
 
 @app.command()

--- a/sdk/cli/commands/session.py
+++ b/sdk/cli/commands/session.py
@@ -5,7 +5,7 @@ from typing import Optional
 import typer
 
 from ..utils.io import load_yaml
-from ..utils.formatting import print_success
+from ..utils.formatting import print_success, print_output
 
 from agentnn.reasoning.context_reasoner import MajorityVoteReasoner
 from agentnn.session.session_manager import SessionManager
@@ -81,11 +81,13 @@ def restore(snapshot_id: str) -> None:
 
 
 @session_app.command("list")
-def session_list() -> None:
+def session_list(
+    output: str = typer.Option("table", "--output", help="table|json|markdown")
+) -> None:
     """List active sessions."""
     client = AgentClient()
-    data = client.list_sessions()
-    typer.echo(json.dumps(data, indent=2))
+    data = client.list_sessions().get("sessions", [])
+    print_output(data, output)
 
 
 @session_app.command("budget")

--- a/sdk/cli/utils/__init__.py
+++ b/sdk/cli/utils/__init__.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import httpx
+import os
 import typer
 
-from .formatting import print_success, print_error
+from .formatting import print_success, print_error, print_output
 from .io import load_yaml, write_json, ensure_parent
 
 
@@ -16,7 +17,12 @@ def handle_http_error(err: httpx.HTTPStatusError) -> None:
             fg=typer.colors.RED,
         )
     else:
-        typer.secho(f"HTTP Error: {err.response.status_code}", fg=typer.colors.RED)
+        typer.secho(
+            f"HTTP Error: {err.response.status_code}", fg=typer.colors.RED
+        )
+    if os.getenv("AGENTNN_DEBUG") == "1":
+        typer.echo(err.response.text)
+        raise
     raise typer.Exit(1)
 
 
@@ -30,6 +36,7 @@ __all__ = [
     "confirm_action",
     "print_success",
     "print_error",
+    "print_output",
     "load_yaml",
     "write_json",
     "ensure_parent",

--- a/sdk/cli/utils/formatting.py
+++ b/sdk/cli/utils/formatting.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import json
+from typing import Any, Dict, List
+
 import typer
+from rich.console import Console
+from rich.table import Table
 
 
 def print_success(msg: str) -> None:
@@ -13,4 +18,25 @@ def print_error(msg: str) -> None:
     typer.secho(msg, fg=typer.colors.RED)
 
 
-__all__ = ["print_success", "print_error"]
+def print_output(data: List[Dict[str, Any]], output: str = "table") -> None:
+    """Render ``data`` in the requested ``output`` format."""
+    if output == "json":
+        typer.echo(json.dumps(data, indent=2))
+        return
+    keys: List[str] = sorted({k for item in data for k in item.keys()})
+    if output == "markdown":
+        header = "| " + " | ".join(keys) + " |"
+        sep = "| " + " | ".join("---" for _ in keys) + " |"
+        rows = [
+            "| " + " | ".join(str(item.get(k, "")) for k in keys) + " |"
+            for item in data
+        ]
+        typer.echo("\n".join([header, sep] + rows))
+        return
+    table = Table(*keys, show_header=True)
+    for item in data:
+        table.add_row(*(str(item.get(k, "")) for k in keys))
+    Console().print(table)
+
+
+__all__ = ["print_success", "print_error", "print_output"]

--- a/tests/cli/test_interactive_mode.py
+++ b/tests/cli/test_interactive_mode.py
@@ -1,0 +1,38 @@
+from typer.testing import CliRunner
+
+from sdk.cli.main import app
+
+
+def test_agent_register_wizard(monkeypatch):
+    from sdk.cli.commands import agent as agent_cmd
+
+    class DummyReg:
+        def __init__(self, endpoint: str) -> None:
+            pass
+
+        def deploy(self, data):
+            return {"ok": data["id"]}
+
+    monkeypatch.setattr(agent_cmd, "AgentRegistry", DummyReg)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["agent", "register", "--interactive"],
+        input="demo\nworker\n\nDemo agent\n",
+    )
+    assert result.exit_code == 0
+    assert "demo" in result.stdout
+
+
+def test_agent_list_markdown(monkeypatch):
+    from sdk.cli.commands import agent as agent_cmd
+
+    monkeypatch.setattr(
+        agent_cmd.AgentClient,
+        "list_agents",
+        lambda self: {"agents": [{"name": "a", "role": "r"}]},
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["agent", "list", "--output", "json"])
+    assert result.exit_code == 0
+    assert '"name": "a"' in result.stdout


### PR DESCRIPTION
## Summary
- add `--verbose`, `--quiet` and `--debug` flags to the root CLI
- implement table/json/markdown rendering via `print_output`
- support `--output` option in agent, session, model and OpenHands commands
- introduce interactive agent registration wizard
- document new flags and examples in `docs/cli.md`
- test interactive CLI workflow

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f46744b0832482ae6e82ab96c10e