### PR TITLE
Add templating and config support to CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,3 +69,33 @@ strukturiert. Dadurch können neue Kommandos leicht angelegt werden, ohne
 unerwünschte Abhängigkeiten zu erzeugen. `main.py` bindet lediglich die
 bereits initialisierten `Typer`-Instanzen ein und enthält keine Logik
 oder Rückimporte.
+
+## ⚙️ Konfiguration & Vorlagen
+
+Beim Start sucht die CLI nach `~/.agentnn/config.toml` und liest globale
+Standardwerte wie `default_session_template`, `output_format` und `log_level`.
+Eine optionale `agentnn.toml` im aktuellen Projektverzeichnis kann diese
+Einstellungen überschreiben.
+
+Beispiel `agentnn.toml`:
+
+```toml
+output_format = "json"
+default_session_template = "project/session.yaml"
+```
+
+Vorlagen liegen unter `~/.agentnn/templates/` und können mit folgenden
+Befehlen verwaltet werden:
+
+```bash
+agentnn template list
+agentnn template show session_template.yaml
+agentnn template init session --output=my.yaml
+```
+
+Quickstart-Kürzel kombinieren Konfiguration und Vorlagen:
+
+```bash
+agentnn quickstart agent --name Demo --role planner
+agentnn quickstart session --template demo_session.yaml
+```

--- a/sdk/cli/commands/config_cmd.py
+++ b/sdk/cli/commands/config_cmd.py
@@ -1,4 +1,5 @@
 """Configuration commands."""
+
 from __future__ import annotations
 
 import json
@@ -6,6 +7,7 @@ import json
 import typer
 
 from ..config import SDKSettings
+from ..config import CLIConfig
 from core.config import settings as core_settings
 
 config_app = typer.Typer(name="config", help="Configuration commands")
@@ -15,7 +17,9 @@ config_app = typer.Typer(name="config", help="Configuration commands")
 def config_show() -> None:
     """Show effective configuration."""
     settings = SDKSettings.load()
-    typer.echo(json.dumps(settings.__dict__, indent=2))
+    cli = CLIConfig.load()
+    data = {"sdk": settings.__dict__, "cli": cli.__dict__}
+    typer.echo(json.dumps(data, indent=2))
 
 
 @config_app.command("check")
@@ -26,5 +30,6 @@ def config_check() -> None:
 
 def register(app: typer.Typer) -> None:
     app.add_typer(config_app)
+
 
 __all__ = ["register", "config_app"]

--- a/sdk/cli/commands/quickstart.py
+++ b/sdk/cli/commands/quickstart.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+import typer
+import yaml
+
+from .session import start as session_start
+from ..config import CLIConfig
+from ..utils.io import ensure_parent
+
+
+quickstart_app = typer.Typer(name="quickstart", help="Automated setup helpers")
+
+
+@quickstart_app.command("agent")
+def quickstart_agent(
+    name: str = typer.Option(...),
+    role: str = typer.Option("planner"),
+    output: Path = typer.Option(Path("agent.yaml")),
+) -> None:
+    """Create a new agent config from template."""
+    built_in = (
+        Path(__file__).resolve().parent.parent / "templates" / "agent_template.yaml"
+    )
+    data = yaml.safe_load(built_in.read_text())
+    data["id"] = name
+    data["role"] = role
+    ensure_parent(output)
+    output.write_text(yaml.safe_dump(data))
+    typer.echo(str(output))
+
+
+@quickstart_app.command("session")
+def quickstart_session(template: str | None = None) -> None:
+    """Start a session using a template."""
+    cfg = CLIConfig.load()
+    path = Path(template or cfg.default_session_template)
+    session_start(template=path)
+
+
+__all__ = ["quickstart_app"]

--- a/sdk/cli/commands/template.py
+++ b/sdk/cli/commands/template.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import typer
+
+from ..config import CLIConfig
+from ..utils.io import ensure_parent
+
+
+template_app = typer.Typer(name="template", help="Manage templates")
+
+
+@template_app.command("list")
+def template_list() -> None:
+    """List available templates."""
+    cfg = CLIConfig.load()
+    directory = Path(os.path.expanduser(cfg.templates_dir))
+    if not directory.exists():
+        typer.echo("no templates")
+        return
+    for item in directory.iterdir():
+        if item.is_file():
+            typer.echo(item.name)
+
+
+@template_app.command("show")
+def template_show(name: str) -> None:
+    """Show template contents."""
+    cfg = CLIConfig.load()
+    path = Path(os.path.expanduser(cfg.templates_dir)) / name
+    if not path.exists():
+        typer.echo("template not found")
+        raise typer.Exit(code=1)
+    typer.echo(path.read_text())
+
+
+@template_app.command("init")
+def template_init(kind: str, output: Path) -> None:
+    """Create template file from built-in defaults."""
+    built_in = (
+        Path(__file__).resolve().parent.parent / "templates" / f"{kind}_template.yaml"
+    )
+    if not built_in.exists():
+        typer.echo("unknown template kind")
+        raise typer.Exit(code=1)
+    ensure_parent(output)
+    output.write_text(built_in.read_text())
+    typer.echo(str(output))
+
+
+__all__ = ["template_app"]

--- a/sdk/cli/config.py
+++ b/sdk/cli/config.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+import tomllib
+from ..config import SDKSettings as _SDKSettings
+
+
+@dataclass
+class CLIConfig:
+    """User and project configuration values."""
+
+    default_session_template: str = "examples/demo.yaml"
+    output_format: str = "table"
+    log_level: str = "INFO"
+    templates_dir: str = "~/.agentnn/templates"
+
+    @classmethod
+    def load(cls) -> "CLIConfig":
+        data: dict[str, str] = {}
+        global_path = Path.home() / ".agentnn" / "config.toml"
+        if global_path.exists():
+            data.update(tomllib.loads(global_path.read_text()))
+        project_path = Path.cwd() / "agentnn.toml"
+        if project_path.exists():
+            data.update(tomllib.loads(project_path.read_text()))
+        if os.getenv("AGENTNN_LOG_LEVEL"):
+            data["log_level"] = os.getenv("AGENTNN_LOG_LEVEL", "")
+
+        return cls(**data)
+
+
+SDKSettings = _SDKSettings
+
+__all__ = ["CLIConfig", "SDKSettings"]

--- a/sdk/cli/main.py
+++ b/sdk/cli/main.py
@@ -1,4 +1,5 @@
 """Modular command line interface for Agent-NN."""
+
 from __future__ import annotations
 
 import typer
@@ -14,6 +15,8 @@ from .commands.agentctl import register as register_agentctl
 from .commands.dispatch import register as register_dispatch
 from .commands.context import context_app
 from .commands.prompt import prompt_app
+from .commands.template import template_app
+from .commands.quickstart import quickstart_app
 
 app = typer.Typer()
 
@@ -25,6 +28,8 @@ app.add_typer(session_app, name="session")
 app.add_typer(agent_app, name="agent")
 app.add_typer(context_app, name="context")
 app.add_typer(prompt_app, name="prompt")
+app.add_typer(template_app, name="template")
+app.add_typer(quickstart_app, name="quickstart")
 register_tasks(app)
 register_model(app)
 register_config(app)

--- a/sdk/cli/templates/agent_template.yaml
+++ b/sdk/cli/templates/agent_template.yaml
@@ -1,0 +1,3 @@
+id: my-agent
+role: planner
+description: Example agent

--- a/sdk/cli/templates/session_template.yaml
+++ b/sdk/cli/templates/session_template.yaml
@@ -1,0 +1,5 @@
+agents:
+  - id: example_agent
+    role: assistant
+tasks:
+  - "Say hello"

--- a/sdk/cli/templates/task_template.yaml
+++ b/sdk/cli/templates/task_template.yaml
@@ -1,0 +1,2 @@
+task: "Describe project status"
+max_tokens: 200

--- a/tests/cli/test_config_resolution.py
+++ b/tests/cli/test_config_resolution.py
@@ -1,0 +1,90 @@
+from typer.testing import CliRunner
+from pathlib import Path
+import sys
+import types
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault(
+    "mcp",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(BaseModel=object, Field=lambda *a, **k: None)
+    ),  # noqa: E501
+)
+sys.modules.setdefault(
+    "agentnn.session.session_manager",
+    types.SimpleNamespace(SessionManager=object),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_ws",
+    types.SimpleNamespace(
+        ws_server=types.SimpleNamespace(broadcast=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_server", types.SimpleNamespace(create_app=lambda: None)
+)
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(  # noqa: E501
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+sys.modules.setdefault(
+    "core.config",
+    types.SimpleNamespace(
+        settings=types.SimpleNamespace(model_dump=lambda: {})
+    ),  # noqa: E501
+)
+sys.modules.setdefault(
+    "core.crypto",
+    types.SimpleNamespace(
+        verify_signature=lambda *a, **k: True,
+        generate_keypair=lambda: ("pub", "priv"),
+    ),
+)
+import sdk.nn_models as _nn  # noqa: E402
+
+sys.modules.setdefault("sdk.cli.nn_models", _nn)
+
+from sdk.cli.main import app  # noqa: E402
+from sdk.cli import config as cli_config  # noqa: E402
+
+
+def test_local_overrides_global(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    global_cfg = home / ".agentnn" / "config.toml"
+    global_cfg.parent.mkdir(parents=True)
+    global_cfg.write_text("output_format = 'table'\n")
+
+    project = tmp_path / "project"
+    project.mkdir()
+    local_cfg = project / "agentnn.toml"
+    local_cfg.write_text("output_format = 'json'\n")
+
+    monkeypatch.setattr(Path, "home", lambda: home)
+    runner = CliRunner()
+
+    def load():
+        return cli_config.CLIConfig.load()
+
+    monkeypatch.chdir(project)
+    result = runner.invoke(app, ["config", "show"])
+    assert result.exit_code == 0
+    assert "json" in result.stdout

--- a/tests/cli/test_template_system.py
+++ b/tests/cli/test_template_system.py
@@ -1,0 +1,106 @@
+from typer.testing import CliRunner
+from pathlib import Path
+import sys
+import types
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault(
+    "mcp",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(BaseModel=object, Field=lambda *a, **k: None)
+    ),  # noqa: E501
+)
+sys.modules.setdefault(
+    "agentnn.session.session_manager",
+    types.SimpleNamespace(SessionManager=object),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_ws",
+    types.SimpleNamespace(
+        ws_server=types.SimpleNamespace(broadcast=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_server", types.SimpleNamespace(create_app=lambda: None)
+)
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(  # noqa: E501
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+sys.modules.setdefault(
+    "core.config",
+    types.SimpleNamespace(
+        settings=types.SimpleNamespace(model_dump=lambda: {})
+    ),  # noqa: E501
+)
+sys.modules.setdefault(
+    "core.crypto",
+    types.SimpleNamespace(
+        verify_signature=lambda *a, **k: True,
+        generate_keypair=lambda: ("pub", "priv"),
+    ),
+)
+import sdk.nn_models as _nn  # noqa: E402
+
+sys.modules.setdefault("sdk.cli.nn_models", _nn)
+
+from sdk.cli.main import app  # noqa: E402
+from sdk.cli import config as cli_config  # noqa: E402
+
+
+def _patch_config(monkeypatch, tmp_path):
+    tpl_dir = tmp_path / "templates"
+    tpl_dir.mkdir()
+    default = tpl_dir / "session_template.yaml"
+    default.write_text("agents: []\ntasks: []")
+
+    def load():
+        return cli_config.CLIConfig(
+            default_session_template=str(default),
+            output_format="table",
+            log_level="INFO",
+            templates_dir=str(tpl_dir),
+        )
+
+    monkeypatch.setattr(
+        cli_config.CLIConfig,
+        "load",
+        classmethod(lambda cls: load()),
+    )
+    return tpl_dir
+
+
+def test_template_init_and_list(monkeypatch, tmp_path):
+    runner = CliRunner()
+    _patch_config(monkeypatch, tmp_path)
+    out = tmp_path / "out.yaml"
+    result = runner.invoke(
+        app,
+        ["template", "init", "session", "--output", str(out)],
+    )
+    assert result.exit_code == 0
+    assert out.exists()
+    result = runner.invoke(app, ["template", "list"])
+    assert result.exit_code == 0
+    assert "session_template.yaml" in result.stdout
+    result = runner.invoke(app, ["template", "show", "session_template.yaml"])
+    assert result.exit_code == 0
+    assert "agents" in result.stdout


### PR DESCRIPTION
## Summary
- implement user/project configuration loader and expose via CLI
- add template management commands
- add quickstart helper commands
- document configuration and template usage
- add tests covering templates and config resolution

## Testing
- `ruff check sdk/cli/commands/template.py sdk/cli/commands/quickstart.py sdk/cli/config.py sdk/cli/commands/config_cmd.py sdk/cli/main.py tests/cli/test_template_system.py tests/cli/test_config_resolution.py`
- `black tests/cli/test_template_system.py tests/cli/test_config_resolution.py sdk/cli/config.py sdk/cli/commands/quickstart.py sdk/cli/commands/template.py`
- `flake8 sdk/cli/config.py sdk/cli/commands/template.py sdk/cli/commands/quickstart.py sdk/cli/commands/config_cmd.py sdk/cli/main.py tests/cli/test_template_system.py tests/cli/test_config_resolution.py`
- `mypy sdk/cli/config.py sdk/cli/commands/quickstart.py sdk/cli/commands/template.py tests/cli/test_template_system.py tests/cli/test_config_resolution.py sdk/cli/commands/config_cmd.py sdk/cli/main.py`
- `pytest tests/cli/test_template_system.py tests/cli/test_config_resolution.py`

------
https://chatgpt.com/codex/tasks/task_e_6866f6e20c4c8324b37a097ded3e4226