### PR TITLE
Add template validation and smart quickstart

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,3 +99,21 @@ Quickstart-Kürzel kombinieren Konfiguration und Vorlagen:
 agentnn quickstart agent --name Demo --role planner
 agentnn quickstart session --template demo_session.yaml
 ```
+
+## \U0001F9E0 Intelligente Templates & Automatisierung
+
+Die Template-Befehle unterstützen nun Schema-Validierung und Konvertierung. Beispiele:
+
+```bash
+agentnn template validate my_agent.yaml
+agentnn template show my_agent.yaml --as json
+agentnn template doc my_agent.yaml > AGENT.md
+```
+
+Mit `quickstart agent --from-description` lässt sich aus einer Kurzbeschreibung automatisch ein Agent-Template erzeugen:
+
+```bash
+agentnn quickstart agent --from-description "Planender Entscheidungsagent mit Zugriff auf Tools" --output agent-smart.yaml
+```
+
+Unvollständige Session-Templates können über `quickstart session --from=partial.yaml --complete` ergänzt werden. Alle Aufrufe werden im Verzeichnis `~/.agentnn/history/` protokolliert.

--- a/sdk/cli/commands/config_cmd.py
+++ b/sdk/cli/commands/config_cmd.py
@@ -7,7 +7,6 @@ import json
 import typer
 
 from ..config import SDKSettings
-from ..config import CLIConfig
 from core.config import settings as core_settings
 
 config_app = typer.Typer(name="config", help="Configuration commands")
@@ -17,6 +16,8 @@ config_app = typer.Typer(name="config", help="Configuration commands")
 def config_show() -> None:
     """Show effective configuration."""
     settings = SDKSettings.load()
+    from ..config import CLIConfig
+
     cli = CLIConfig.load()
     data = {"sdk": settings.__dict__, "cli": cli.__dict__}
     typer.echo(json.dumps(data, indent=2))

--- a/sdk/cli/commands/quickstart.py
+++ b/sdk/cli/commands/quickstart.py
@@ -3,38 +3,75 @@ from __future__ import annotations
 from pathlib import Path
 import typer
 import yaml
+import re
+
+from ..utils.history import log_entry
 
 from .session import start as session_start
-from ..config import CLIConfig
 from ..utils.io import ensure_parent
 
 
 quickstart_app = typer.Typer(name="quickstart", help="Automated setup helpers")
 
 
+def _gen_from_desc(desc: str) -> dict:
+    slug = re.sub(r"\W+", "-", desc.lower()).strip("-")[:15] or "agent"
+    role = "planner" if "plan" in desc.lower() else "assistant"
+    return {"id": slug, "role": role, "description": desc, "tools": []}
+
+
 @quickstart_app.command("agent")
 def quickstart_agent(
-    name: str = typer.Option(...),
-    role: str = typer.Option("planner"),
+    name: str | None = typer.Option(None),
+    role: str | None = typer.Option(None),
     output: Path = typer.Option(Path("agent.yaml")),
+    from_description: str | None = typer.Option(None, "--from-description"),
 ) -> None:
-    """Create a new agent config from template."""
-    built_in = (
-        Path(__file__).resolve().parent.parent / "templates" / "agent_template.yaml"
-    )
-    data = yaml.safe_load(built_in.read_text())
-    data["id"] = name
-    data["role"] = role
+    """Create a new agent config from template or description."""
+    if from_description:
+        data = _gen_from_desc(from_description)
+    else:
+        built_in = (
+            Path(__file__).resolve().parent.parent / "templates" / "agent_template.yaml"
+        )
+        data = yaml.safe_load(built_in.read_text())
+    if name:
+        data["id"] = name
+    if role:
+        data["role"] = role
     ensure_parent(output)
     output.write_text(yaml.safe_dump(data))
+    log_entry("quickstart_agent", {"output": str(output)})
     typer.echo(str(output))
 
 
 @quickstart_app.command("session")
-def quickstart_session(template: str | None = None) -> None:
+def quickstart_session(
+    template: str | None = None,
+    from_: Path | None = typer.Option(None, "--from"),
+    complete: bool = typer.Option(False, "--complete"),
+) -> None:
     """Start a session using a template."""
+    from ..config import CLIConfig
+
     cfg = CLIConfig.load()
-    path = Path(template or cfg.default_session_template)
+    if from_:
+        data = yaml.safe_load(from_.read_text())
+        if complete:
+            built_in = (
+                Path(__file__).resolve().parent.parent / "templates" / "session_template.yaml"
+            )
+            defaults = yaml.safe_load(built_in.read_text())
+            for k, v in defaults.items():
+                data.setdefault(k, v)
+            tmp = from_.with_suffix(".complete.yaml")
+            tmp.write_text(yaml.safe_dump(data))
+            path = tmp
+        else:
+            path = from_
+    else:
+        path = Path(template or cfg.default_session_template)
+    log_entry("quickstart_session", {"template": str(path)})
     session_start(template=path)
 
 

--- a/sdk/cli/commands/template.py
+++ b/sdk/cli/commands/template.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 import typer
+import yaml
+from rich.console import Console
+from rich.syntax import Syntax
+import jsonschema
 
-from ..config import CLIConfig
 from ..utils.io import ensure_parent
 
 
@@ -14,6 +18,8 @@ template_app = typer.Typer(name="template", help="Manage templates")
 @template_app.command("list")
 def template_list() -> None:
     """List available templates."""
+    from ..config import CLIConfig
+
     cfg = CLIConfig.load()
     directory = Path(os.path.expanduser(cfg.templates_dir))
     if not directory.exists():
@@ -25,14 +31,61 @@ def template_list() -> None:
 
 
 @template_app.command("show")
-def template_show(name: str) -> None:
+def template_show(name: str, as_: str = typer.Option("yaml", "--as")) -> None:
     """Show template contents."""
+    from ..config import CLIConfig
+
     cfg = CLIConfig.load()
     path = Path(os.path.expanduser(cfg.templates_dir)) / name
     if not path.exists():
         typer.echo("template not found")
         raise typer.Exit(code=1)
-    typer.echo(path.read_text())
+    text = path.read_text()
+    if as_ == "json":
+        data = yaml.safe_load(text)
+        typer.echo(json.dumps(data, indent=2))
+    else:
+        console = Console()
+        console.print(Syntax(text, "yaml", line_numbers=True))
+
+
+@template_app.command("doc")
+def template_doc(name: str) -> None:
+    """Output Markdown documentation for template."""
+    from ..config import CLIConfig
+
+    cfg = CLIConfig.load()
+    path = Path(os.path.expanduser(cfg.templates_dir)) / name
+    if not path.exists():
+        typer.echo("template not found")
+        raise typer.Exit(code=1)
+    text = path.read_text()
+    typer.echo("```yaml\n" + text + "\n```")
+
+
+@template_app.command("validate")
+def template_validate(path: Path, kind: str | None = None) -> None:
+    """Validate template against built-in schema."""
+    text = path.read_text()
+    data = yaml.safe_load(text)
+    if not kind:
+        if isinstance(data, dict) and "agents" in data and "tasks" in data:
+            kind = "session"
+        elif isinstance(data, dict) and "task" in data:
+            kind = "task"
+        else:
+            kind = "agent"
+    schema_file = (
+        Path(__file__).resolve().parent.parent / "schemas" / f"{kind}_schema.json"
+    )
+    schema = json.loads(schema_file.read_text())
+    try:
+        jsonschema.validate(data, schema)
+    except jsonschema.ValidationError as exc:
+        typer.secho("Ungültig", fg=typer.colors.RED)
+        typer.echo(str(exc).split("\n", 1)[0])
+        raise typer.Exit(1)
+    typer.secho("Gültig", fg=typer.colors.GREEN)
 
 
 @template_app.command("init")
@@ -49,4 +102,4 @@ def template_init(kind: str, output: Path) -> None:
     typer.echo(str(output))
 
 
-__all__ = ["template_app"]
+__all__ = ["template_app", "template_validate", "template_doc", "template_show"]

--- a/sdk/cli/schemas/agent_schema.json
+++ b/sdk/cli/schemas/agent_schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "required": ["id", "role"],
+  "properties": {
+    "id": {"type": "string"},
+    "role": {"type": "string"},
+    "description": {"type": "string"},
+    "tools": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": true
+}

--- a/sdk/cli/schemas/session_schema.json
+++ b/sdk/cli/schemas/session_schema.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "required": ["agents", "tasks"],
+  "properties": {
+    "agents": {"type": "array", "items": {"type": "object"}},
+    "tasks": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": true
+}

--- a/sdk/cli/schemas/task_schema.json
+++ b/sdk/cli/schemas/task_schema.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "required": ["task"],
+  "properties": {
+    "task": {"type": "string"},
+    "max_tokens": {"type": "integer"}
+  },
+  "additionalProperties": true
+}

--- a/sdk/cli/utils/__init__.py
+++ b/sdk/cli/utils/__init__.py
@@ -7,6 +7,7 @@ import typer
 
 from .formatting import print_success, print_error, print_output
 from .io import load_yaml, write_json, ensure_parent
+from .history import log_entry
 
 
 def handle_http_error(err: httpx.HTTPStatusError) -> None:
@@ -40,4 +41,5 @@ __all__ = [
     "load_yaml",
     "write_json",
     "ensure_parent",
+    "log_entry",
 ]

--- a/sdk/cli/utils/history.py
+++ b/sdk/cli/utils/history.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+HISTORY_DIR = Path.home() / ".agentnn" / "history"
+HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def log_entry(command: str, params: Dict[str, Any]) -> None:
+    """Append ``params`` for ``command`` to history."""
+    entry = {"command": command, "params": params, "ts": datetime.utcnow().isoformat()}
+    path = HISTORY_DIR / f"{command.replace(' ', '_')}.log"
+    with path.open("a") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+__all__ = ["log_entry"]

--- a/tests/cli/test_quickstart_generation.py
+++ b/tests/cli/test_quickstart_generation.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.modules.setdefault(
+    "mcp",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(BaseModel=object, Field=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.session.session_manager",
+    types.SimpleNamespace(SessionManager=object),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_ws",
+    types.SimpleNamespace(ws_server=types.SimpleNamespace(broadcast=lambda *a, **k: None)),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_server", types.SimpleNamespace(create_app=lambda: None)
+)
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+sys.modules.setdefault(
+    "core.config",
+    types.SimpleNamespace(settings=types.SimpleNamespace(model_dump=lambda: {})),
+)
+sys.modules.setdefault(
+    "core.crypto",
+    types.SimpleNamespace(
+        verify_signature=lambda *a, **k: True,
+        generate_keypair=lambda: ("pub", "priv"),
+    ),
+)
+import sdk.nn_models as _nn  # noqa: E402
+sys.modules.setdefault("sdk.cli.nn_models", _nn)
+
+from typer.testing import CliRunner
+import pytest
+import yaml
+
+from sdk.cli.main import app
+from sdk.cli import config as cli_config
+
+
+def _patch_config(monkeypatch, tmp_path: Path) -> Path:
+    tpl_dir = tmp_path / "templates"
+    tpl_dir.mkdir()
+    default = tpl_dir / "session_template.yaml"
+    default.write_text("agents: []\ntasks: []")
+
+    def load():
+        return cli_config.CLIConfig(
+            default_session_template=str(default),
+            output_format="table",
+            log_level="INFO",
+            templates_dir=str(tpl_dir),
+        )
+
+    monkeypatch.setattr(cli_config.CLIConfig, "load", classmethod(lambda cls: load()))
+    return tpl_dir
+
+
+@pytest.mark.unit
+def test_quickstart_agent_from_description(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    _patch_config(monkeypatch, tmp_path)
+    out = tmp_path / "agent.yaml"
+    result = runner.invoke(
+        app,
+        ["quickstart", "agent", "--from-description", "Demo agent", "--output", str(out)],
+    )
+    assert result.exit_code == 0
+    data = yaml.safe_load(out.read_text())
+    assert data["description"] == "Demo agent"
+
+
+@pytest.mark.unit
+def test_quickstart_session_complete(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    _patch_config(monkeypatch, tmp_path)
+    from sdk.cli.commands import session as session_cmd
+
+    class DummyManager:
+        def create_session(self):
+            return "sid"
+
+        def add_agent(self, *a, **k):
+            pass
+
+        def run_task(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(session_cmd, "manager", DummyManager())
+    part = tmp_path / "part.yaml"
+    part.write_text("agents: []")
+    result = runner.invoke(
+        app,
+        ["quickstart", "session", "--from", str(part), "--complete"],
+    )
+    assert result.exit_code == 0
+    assert part.with_suffix(".complete.yaml").exists()

--- a/tests/cli/test_template_validation.py
+++ b/tests/cli/test_template_validation.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.modules.setdefault(
+    "mcp",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(BaseModel=object, Field=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.session.session_manager",
+    types.SimpleNamespace(SessionManager=object),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_ws",
+    types.SimpleNamespace(ws_server=types.SimpleNamespace(broadcast=lambda *a, **k: None)),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_server", types.SimpleNamespace(create_app=lambda: None)
+)
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+sys.modules.setdefault(
+    "core.config",
+    types.SimpleNamespace(settings=types.SimpleNamespace(model_dump=lambda: {})),
+)
+sys.modules.setdefault(
+    "core.crypto",
+    types.SimpleNamespace(
+        verify_signature=lambda *a, **k: True,
+        generate_keypair=lambda: ("pub", "priv"),
+    ),
+)
+import sdk.nn_models as _nn  # noqa: E402
+sys.modules.setdefault("sdk.cli.nn_models", _nn)
+
+from typer.testing import CliRunner
+import pytest
+
+from sdk.cli.main import app
+from sdk.cli import config as cli_config
+
+
+def _patch_config(monkeypatch, tmp_path: Path) -> Path:
+    tpl_dir = tmp_path / "templates"
+    tpl_dir.mkdir()
+    default = tpl_dir / "session_template.yaml"
+    default.write_text("agents: []\ntasks: []")
+
+    def load():
+        return cli_config.CLIConfig(
+            default_session_template=str(default),
+            output_format="table",
+            log_level="INFO",
+            templates_dir=str(tpl_dir),
+        )
+
+    monkeypatch.setattr(cli_config.CLIConfig, "load", classmethod(lambda cls: load()))
+    return tpl_dir
+
+
+@pytest.mark.unit
+def test_template_validate(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    _patch_config(monkeypatch, tmp_path)
+    cfg = tmp_path / "agent.yaml"
+    cfg.write_text("id: demo\nrole: assistant")
+    result = runner.invoke(app, ["template", "validate", str(cfg)])
+    assert result.exit_code == 0
+    assert "G\u00fcltig" in result.stdout
+
+
+@pytest.mark.unit
+def test_template_validate_fail(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    _patch_config(monkeypatch, tmp_path)
+    cfg = tmp_path / "bad.yaml"
+    cfg.write_text("role: assistant")
+    result = runner.invoke(app, ["template", "validate", str(cfg)])
+    assert result.exit_code != 0
+    assert "Ung\u00fcltig" in result.stdout


### PR DESCRIPTION
## Summary
- support schema validation and format conversion for templates
- extend quickstart with description-based agent generation
- add history logging utility
- update CLI documentation
- test new quickstart and template features

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest -q`
- `pytest tests/cli/test_quickstart_generation.py tests/cli/test_template_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6866fb86a9d48324820352c672493c8d