### PR TITLE
Enhance CLI feature coverage

### DIFF
--- a/core/voting.py
+++ b/core/voting.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import List, Optional
+
+VOTE_DIR = Path(os.getenv("VOTE_DIR", "votes"))
+
+
+@dataclass
+class ProposalVote:
+    """A single vote for a governance proposal."""
+
+    proposal_id: str
+    agent_id: str
+    decision: str  # yes or no
+    comment: Optional[str]
+    created_at: str
+
+
+def _path(pid: str) -> Path:
+    VOTE_DIR.mkdir(parents=True, exist_ok=True)
+    return VOTE_DIR / f"{pid}.jsonl"
+
+
+def record_vote(vote: ProposalVote) -> None:
+    """Persist ``vote`` in ``VOTE_DIR``."""
+    path = _path(vote.proposal_id)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(asdict(vote)) + "\n")
+
+
+def load_votes(pid: str) -> List[ProposalVote]:
+    """Return all votes for ``pid``."""
+    path = _path(pid)
+    if not path.exists():
+        return []
+    votes: List[ProposalVote] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            data = json.loads(line)
+            votes.append(ProposalVote(**data))
+    return votes

--- a/sdk/cli/commands/dispatch.py
+++ b/sdk/cli/commands/dispatch.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 import typer
 
@@ -10,10 +11,20 @@ def register(app: typer.Typer) -> None:
     """Register dispatch command on ``app``."""
 
     @app.command("dispatch")
-    def dispatch(task: str) -> None:
-        """Send TASK to the dispatcher and output the result."""
+    def dispatch(
+        task: str = "",
+        from_stdin: bool = typer.Option(
+            False, "--from-stdin", help="read JSON task from stdin"
+        ),
+    ) -> None:
+        """Send ``task`` to the dispatcher and output the result."""
+        if from_stdin:
+            data = json.loads(sys.stdin.read() or "{}")
+            task = data.get("task", task)
+        if not task:
+            typer.echo("missing task")
+            raise typer.Exit(1)
         client = AgentClient()
         ctx = ModelContext(task_context=TaskContext(task_type="chat", description=task))
         result = client.dispatch_task(ctx)
         typer.echo(json.dumps(result))
-

--- a/sdk/cli/commands/feedback.py
+++ b/sdk/cli/commands/feedback.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+import typer
+
+from ...client import AgentClient
+
+feedback_app = typer.Typer(name="feedback", help="Feedback utilities")
+
+
+@feedback_app.command("record")
+def feedback_record(
+    session: str = "",
+    score: int = typer.Option(..., "--score"),
+    comment: str = typer.Option("", "--comment"),
+    agent: str = typer.Option(None, "--agent"),
+    interactive: bool = typer.Option(False, "--interactive"),
+) -> None:
+    """Send a feedback entry."""
+    if interactive:
+        if not session:
+            session = typer.prompt("Session id")
+        if not score:
+            score = int(typer.prompt("Score"))
+        comment = typer.prompt("Comment", default=comment)
+    payload = {
+        "session_id": session,
+        "user_id": "default",
+        "agent_id": agent or "",
+        "score": score,
+        "comment": comment or None,
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    client = AgentClient()
+    result = client.post_feedback(session, payload)
+    typer.echo(json.dumps(result))
+
+
+@feedback_app.command("list")
+def feedback_list(session: str) -> None:
+    """List feedback for SESSION."""
+    client = AgentClient()
+    result = client.get_feedback(session)
+    typer.echo(json.dumps(result, indent=2))

--- a/sdk/cli/commands/tools.py
+++ b/sdk/cli/commands/tools.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+import typer
+
+from plugins.loader import PluginManager
+
+tools_app = typer.Typer(name="tools", help="Tool registry")
+
+
+@tools_app.command("list")
+def tools_list() -> None:
+    """List available tool plugins."""
+    mgr = PluginManager()
+    typer.echo(json.dumps(mgr.list_plugins(), indent=2))
+
+
+@tools_app.command("inspect")
+def tools_inspect(name: str) -> None:
+    """Show details for ``name``."""
+    mgr = PluginManager()
+    plugin = mgr.get(name)
+    if not plugin:
+        typer.echo("not found")
+        raise typer.Exit(1)
+    typer.echo(plugin.__class__.__name__)

--- a/sdk/cli/commands/train.py
+++ b/sdk/cli/commands/train.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import typer
+from datetime import datetime
+
+from core.agent_profile import AgentIdentity
+from core.audit_log import AuditEntry, AuditLog
+
+train_app = typer.Typer(name="train", help="Training management")
+
+
+@train_app.command("start")
+def train_start(
+    agent: str,
+    path: str = typer.Option(..., "--path"),
+    interactive: bool = typer.Option(False, "--interactive"),
+) -> None:
+    """Start a training path for ``agent``."""
+    if interactive:
+        agent = typer.prompt("Agent", default=agent)
+        path = typer.prompt("Path", default=path)
+    profile = AgentIdentity.load(agent)
+    profile.training_progress[path] = "in_progress"
+    profile.save()
+    log = AuditLog()
+    log.write(
+        AuditEntry(
+            timestamp=datetime.utcnow().isoformat(),
+            actor="cli",
+            action="training_started",
+            context_id=agent,
+            detail={"path": path},
+        )
+    )
+    typer.echo("started")

--- a/sdk/cli/main.py
+++ b/sdk/cli/main.py
@@ -11,6 +11,9 @@ from .commands.tasks import register as register_tasks, task_app
 from .commands.model import register as register_model
 from .commands.config_cmd import register as register_config
 from .commands.governance import register as register_governance
+from .commands.feedback import feedback_app
+from .commands.tools import tools_app
+from .commands.train import train_app
 from .commands.agentctl import register as register_agentctl
 from .commands.dispatch import register as register_dispatch
 from .commands.context import context_app
@@ -30,6 +33,9 @@ app.add_typer(context_app, name="context")
 app.add_typer(prompt_app, name="prompt")
 app.add_typer(template_app, name="template")
 app.add_typer(quickstart_app, name="quickstart")
+app.add_typer(feedback_app, name="feedback")
+app.add_typer(tools_app, name="tools")
+app.add_typer(train_app, name="train")
 register_tasks(app)
 register_model(app)
 register_config(app)

--- a/tests/cli/test_batch_inputs.py
+++ b/tests/cli/test_batch_inputs.py
@@ -1,0 +1,80 @@
+from typer.testing import CliRunner
+
+import sys
+import types
+
+sys.modules.setdefault(
+    "mcp",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(BaseModel=object, Field=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.session.session_manager",
+    types.SimpleNamespace(SessionManager=object),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_ws",
+    types.SimpleNamespace(
+        ws_server=types.SimpleNamespace(broadcast=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_server", types.SimpleNamespace(create_app=lambda: None)
+)
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+sys.modules.setdefault(
+    "core.crypto",
+    types.SimpleNamespace(
+        generate_keypair=lambda *a, **k: None,
+        verify_signature=lambda *a, **k: True,
+    ),
+)
+sys.modules.setdefault(
+    "jsonschema", types.SimpleNamespace(validate=lambda *a, **k: None)
+)
+import sdk.nn_models as _nn  # noqa: E402
+
+sys.modules.setdefault("sdk.cli.nn_models", _nn)
+sys.modules.setdefault(
+    "core.config",
+    types.SimpleNamespace(settings=types.SimpleNamespace(model_dump=lambda: {})),
+)
+
+from sdk.cli.main import app  # noqa: E402
+
+
+def test_dispatch_from_stdin(monkeypatch):
+    from sdk.cli.commands import dispatch as dispatch_cmd
+
+    class DummyClient:
+        def dispatch_task(self, ctx):
+            return {"ok": True}
+
+    monkeypatch.setattr(dispatch_cmd, "AgentClient", lambda: DummyClient())
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["task", "dispatch", "--from-stdin"],
+        input='{"task":"hi"}',
+    )
+    assert result.exit_code == 0
+    assert "ok" in result.stdout

--- a/tests/cli/test_governance_commands.py
+++ b/tests/cli/test_governance_commands.py
@@ -1,0 +1,91 @@
+from typer.testing import CliRunner
+
+import sys
+import types
+
+sys.modules.setdefault(
+    "mcp",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(BaseModel=object, Field=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.session.session_manager",
+    types.SimpleNamespace(SessionManager=object),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_ws",
+    types.SimpleNamespace(
+        ws_server=types.SimpleNamespace(broadcast=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_server", types.SimpleNamespace(create_app=lambda: None)
+)
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+sys.modules.setdefault(
+    "core.crypto",
+    types.SimpleNamespace(
+        generate_keypair=lambda *a, **k: None,
+        verify_signature=lambda *a, **k: True,
+    ),
+)
+sys.modules.setdefault(
+    "jsonschema", types.SimpleNamespace(validate=lambda *a, **k: None)
+)
+import sdk.nn_models as _nn  # noqa: E402
+
+sys.modules.setdefault("sdk.cli.nn_models", _nn)
+sys.modules.setdefault(
+    "core.config",
+    types.SimpleNamespace(settings=types.SimpleNamespace(model_dump=lambda: {})),
+)
+
+from sdk.cli.main import app  # noqa: E402
+
+
+def test_governance_vote(monkeypatch, tmp_path):
+    from sdk.cli.commands import governance as gov_cmd
+
+    called = {}
+
+    def fake_record(vote):
+        called["vote"] = vote
+
+    monkeypatch.setattr(gov_cmd, "record_vote", fake_record)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["governance", "vote", "p1", "--agent", "demo", "--decision", "yes"],
+    )
+    assert result.exit_code == 0
+    assert "recorded" in result.stdout
+    assert called["vote"].proposal_id == "p1"
+
+
+def test_governance_log(monkeypatch):
+    from sdk.cli.commands import governance as gov_cmd
+
+    monkeypatch.setattr(gov_cmd, "load_votes", lambda p: [])
+    runner = CliRunner()
+    result = runner.invoke(app, ["governance", "log", "p1"])
+    assert result.exit_code == 0
+    assert "[]" in result.stdout

--- a/tests/cli/test_interactive_feedback.py
+++ b/tests/cli/test_interactive_feedback.py
@@ -1,0 +1,80 @@
+from typer.testing import CliRunner
+
+import sys
+import types
+
+sys.modules.setdefault(
+    "mcp",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(BaseModel=object, Field=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.session.session_manager",
+    types.SimpleNamespace(SessionManager=object),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_ws",
+    types.SimpleNamespace(
+        ws_server=types.SimpleNamespace(broadcast=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_server", types.SimpleNamespace(create_app=lambda: None)
+)
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+sys.modules.setdefault(
+    "core.crypto",
+    types.SimpleNamespace(
+        generate_keypair=lambda *a, **k: None,
+        verify_signature=lambda *a, **k: True,
+    ),
+)
+sys.modules.setdefault(
+    "jsonschema", types.SimpleNamespace(validate=lambda *a, **k: None)
+)
+import sdk.nn_models as _nn  # noqa: E402
+
+sys.modules.setdefault("sdk.cli.nn_models", _nn)
+sys.modules.setdefault(
+    "core.config",
+    types.SimpleNamespace(settings=types.SimpleNamespace(model_dump=lambda: {})),
+)
+
+from sdk.cli.main import app  # noqa: E402
+
+
+def test_feedback_record_interactive(monkeypatch):
+    from sdk.cli.commands import feedback as fb_cmd
+
+    class DummyClient:
+        def post_feedback(self, session, payload):
+            return {"ok": True}
+
+    monkeypatch.setattr(fb_cmd, "AgentClient", lambda: DummyClient())
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["feedback", "record", "--interactive"],
+        input="sid\n1\nGreat\n",
+    )
+    assert result.exit_code == 0
+    assert "ok" in result.stdout

--- a/tests/cli/test_tool_registry.py
+++ b/tests/cli/test_tool_registry.py
@@ -1,0 +1,98 @@
+from typer.testing import CliRunner
+
+import sys
+import types
+
+sys.modules.setdefault(
+    "mcp",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(BaseModel=object, Field=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.session.session_manager",
+    types.SimpleNamespace(SessionManager=object),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_ws",
+    types.SimpleNamespace(
+        ws_server=types.SimpleNamespace(broadcast=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_server", types.SimpleNamespace(create_app=lambda: None)
+)
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+sys.modules.setdefault(
+    "core.crypto",
+    types.SimpleNamespace(
+        generate_keypair=lambda *a, **k: None,
+        verify_signature=lambda *a, **k: True,
+    ),
+)
+sys.modules.setdefault(
+    "jsonschema", types.SimpleNamespace(validate=lambda *a, **k: None)
+)
+import sdk.nn_models as _nn  # noqa: E402
+
+sys.modules.setdefault("sdk.cli.nn_models", _nn)
+sys.modules.setdefault(
+    "core.config",
+    types.SimpleNamespace(settings=types.SimpleNamespace(model_dump=lambda: {})),
+)
+
+from sdk.cli.main import app  # noqa: E402
+
+
+def test_tools_list(monkeypatch):
+    from sdk.cli.commands import tools as tools_cmd
+
+    class DummyMgr:
+        def list_plugins(self):
+            return ["fs"]
+
+        def get(self, name):
+            return object()
+
+    monkeypatch.setattr(tools_cmd, "PluginManager", lambda: DummyMgr())
+    runner = CliRunner()
+    result = runner.invoke(app, ["tools", "list"])
+    assert result.exit_code == 0
+    assert "fs" in result.stdout
+
+
+def test_tools_inspect(monkeypatch):
+    from sdk.cli.commands import tools as tools_cmd
+
+    class DummyMgr:
+        def list_plugins(self):
+            return []
+
+        def get(self, name):
+            if name == "fs":
+                return DummyMgr()
+            return None
+
+    monkeypatch.setattr(tools_cmd, "PluginManager", lambda: DummyMgr())
+    runner = CliRunner()
+    result = runner.invoke(app, ["tools", "inspect", "fs"])
+    assert result.exit_code == 0
+    assert "DummyMgr" in result.stdout


### PR DESCRIPTION
## Summary
- add new governance vote/audit/log commands and voting storage
- support stdin input for task dispatch
- introduce feedback, tools and train command groups
- expose PluginManager via CLI
- unit tests for new CLI utilities

## Testing
- `ruff check tests/cli/test_governance_commands.py tests/cli/test_batch_inputs.py tests/cli/test_tool_registry.py tests/cli/test_interactive_feedback.py core/voting.py sdk/cli/commands/dispatch.py sdk/cli/commands/feedback.py sdk/cli/commands/tools.py sdk/cli/commands/train.py sdk/cli/commands/governance.py`
- `mypy mcp || true`
- `pytest tests/cli/test_governance_commands.py tests/cli/test_batch_inputs.py tests/cli/test_tool_registry.py tests/cli/test_interactive_feedback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6867628187a883249c1695adb2491c1e