### PR TITLE
Fix tests by installing missing CLI deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,6 @@ mcp
 structlog>=23.0.0
 aiofiles
 tqdm
+typer
+cryptography
+jsonschema


### PR DESCRIPTION
## Summary
- add Typer, cryptography and jsonschema to requirements

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686765b9653083248c80d43b624ccad9