### PR TITLE
Document CLI usage

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,14 +7,23 @@ Install the project and run `agentnn --help` to see available commands.
 
 | Command | Description |
 |---------|-------------|
-| `session` | manage and track conversation sessions |
-| `context` | export stored context data and context maps |
 | `agent` | inspect and update agent profiles |
-| `task` | queue and inspect tasks |
+| `session` | manage and track conversation sessions |
+| `task` | queue utilities and task helpers |
+| `queue` | inspect dispatcher queue |
 | `model` | list and switch language models |
+| `context` | export stored context data and context maps |
 | `prompt` | refine prompts and check quality |
+| `template` | manage built‑in templates |
+| `quickstart` | start wizards for agents and sessions |
+| `train` | track training progress |
+| `feedback` | record user feedback |
+| `tools` | inspect available plugins |
 | `config` | show effective configuration |
 | `governance` | governance and trust utilities |
+| `dispatch` | low level dispatcher call |
+| `submit` | submit a task with metadata |
+| `ask` | send a quick chat request |
 | `reset` | remove session history and user data |
 
 ## Examples
@@ -113,3 +122,44 @@ agentnn quickstart agent --from-description "Planender Entscheidungsagent mit Zu
 ```
 
 Unvollständige Session-Templates können über `quickstart session --from=partial.yaml --complete` ergänzt werden. Alle Aufrufe werden im Verzeichnis `~/.agentnn/history/` protokolliert.
+
+## 🧙 Interaktive Wizards – Schritt für Schritt
+
+Viele Befehle besitzen einen geführten Wizard-Modus. Er wird mit `--interactive`
+oder über `agentnn quickstart` aktiviert und fragt alle notwendigen Angaben
+nacheinander ab.
+
+### Agent registrieren
+
+```bash
+agentnn agent register --interactive
+```
+
+Beispielausgabe:
+
+```
+Agent name: DemoAgent
+Role [assistant]: planner
+Tools (comma separated): search
+Description: Beispielagent
+```
+
+Nach Bestätigung wird die Konfiguration an die Registry gesendet und unter
+`~/.agentnn/history/` protokolliert.
+
+### Session starten
+
+```bash
+agentnn quickstart session
+```
+
+Der Wizard erstellt eine Session-Vorlage aus den Standardwerten und startet
+eine neue Unterhaltung. Mit `--from=<datei>` kann eine vorhandene Vorlage
+verwendet werden. Das Flag `--complete` ergänzt fehlende Felder automatisch.
+
+### Weitere Tipps
+
+- `--preset` lädt gespeicherte Einstellungen aus `~/.agentnn/presets/`.
+- `--last` nutzt die zuletzt verwendete Vorlage erneut.
+- Abgebrochene Wizards lassen sich jederzeit neu starten.
+

--- a/docs/cli_dev.md
+++ b/docs/cli_dev.md
@@ -1,0 +1,43 @@
+# Developer Guide: Extending the CLI
+
+Dieses Dokument erklärt, wie neue Unterbefehle für `agentnn` erstellt werden.
+
+## Neues Subkommando anlegen
+
+1. Erzeuge ein Modul unter `sdk/cli/commands/`:
+
+   ```python
+   # sdk/cli/commands/example.py
+   import typer
+
+   example_app = typer.Typer(name="example", help="Beispielbefehle")
+
+   @example_app.command("hello")
+   def hello(name: str = "World") -> None:
+       """Gibt eine Begrüßung aus."""
+       typer.echo(f"Hello {name}")
+   ```
+
+2. Registriere das neue Typer-Objekt in `sdk/cli/main.py`:
+
+   ```python
+   from .commands.example import example_app
+   app.add_typer(example_app, name="example")
+   ```
+
+3. Füge falls nötig Tests unter `tests/cli/` hinzu und dokumentiere das Kommando.
+
+## Konventionen
+
+- Alle Befehle sollten englische Funktionsnamen besitzen und eine kurze Hilfe über `help=` angeben.
+- Längere Erläuterungen oder Beispiele kommen in `epilog=`.
+- Für optionale Dokumentationsausgabe kann das Hilfs-Callback `doc_printer()` verwendet werden.
+- Logging und Fehlerausgaben erfolgen über die Funktionen in `sdk/cli/utils/formatting.py`.
+
+## Beispielaufruf
+
+```bash
+agentnn example hello --name Alice
+```
+
+Weitere Beispiele befinden sich in `docs/cli.md`.

--- a/docs/cli_quickstart.md
+++ b/docs/cli_quickstart.md
@@ -1,0 +1,38 @@
+# CLI Quickstart
+
+Diese Anleitung führt in wenigen Schritten von der Installation bis zur ersten ausgeführten Aufgabe.
+
+1. **Agent anlegen**
+   
+   ```bash
+   agentnn quickstart agent --name MyAgent
+   ```
+   
+   Dadurch entsteht eine einfache `agent.yaml` im aktuellen Verzeichnis.
+
+2. **Session starten**
+   
+   ```bash
+   agentnn session start agent.yaml
+   ```
+   
+   Die CLI gibt eine `session_id` aus, unter der alle weiteren Aufgaben laufen.
+
+3. **Aufgabe übermitteln**
+   
+   ```bash
+   echo '{"task": "Sag Hallo"}' | agentnn dispatch --from-stdin
+   ```
+   
+   Ergebnisse erscheinen als JSON und können per `jq` oder ähnlichen Tools weiterverarbeitet werden.
+
+## Automatisierung mit Templates
+
+Vorlagen in `~/.agentnn/templates/` erlauben es, wiederkehrende Sessions oder Agenten schnell zu starten:
+
+```bash
+agentnn template init session --output=my_session.yaml
+agentnn quickstart session --from=my_session.yaml
+```
+
+Alle Befehle akzeptieren Eingaben über `stdin`, sodass komplexe Workflows scriptbar sind.

--- a/sdk/cli/commands/agent.py
+++ b/sdk/cli/commands/agent.py
@@ -12,6 +12,7 @@ import typer
 import httpx
 
 from ..utils import handle_http_error, print_output
+from ..utils.formatting import doc_printer
 from ..client import AgentClient
 from agentnn.deployment.agent_registry import AgentRegistry, load_agent_file
 from core.agent_profile import PROFILE_DIR, AgentIdentity
@@ -48,13 +49,24 @@ def agents(output: str = typer.Option("table", "--output", help="table|json|mark
     print_output(result.get("agents", []), output)
 
 
-@agent_app.command("register")
+@agent_app.command(
+    "register",
+    help="Register an agent configuration with the registry.",
+    epilog="Beispiel: agentnn agent register config/agent.yaml",
+)
 def agent_register(
     config: Path | None = None,
     endpoint: str = "http://localhost:8090",
     interactive: bool = typer.Option(False, "--interactive", help="use wizard"),
+    docs: bool = typer.Option(
+        False,
+        "--docs",
+        callback=doc_printer("docs/cli.md#agent-registrieren"),
+        is_eager=True,
+        expose_value=False,
+        help="show documentation and exit",
+    ),
 ) -> None:
-    """Register an agent configuration with the registry."""
     if interactive or not config:
         typer.echo("Interactive agent setup")
         name = typer.prompt("Agent name")

--- a/sdk/cli/utils/formatting.py
+++ b/sdk/cli/utils/formatting.py
@@ -39,4 +39,18 @@ def print_output(data: List[Dict[str, Any]], output: str = "table") -> None:
     Console().print(table)
 
 
-__all__ = ["print_success", "print_error", "print_output"]
+def doc_printer(path: str) -> callable:
+    """Return a callback that prints ``path`` and exits."""
+
+    def _printer(
+        ctx: typer.Context, param: typer.CallbackParam, value: bool
+    ) -> None:
+        if not value or ctx.resilient_parsing:
+            return
+        typer.echo(f"Weitere Beispiele: {path}")
+        raise typer.Exit()
+
+    return _printer
+
+
+__all__ = ["print_success", "print_error", "print_output", "doc_printer"]


### PR DESCRIPTION
## Summary
- expand CLI documentation with all commands
- add Quickstart and Developer guide
- integrate wizard walkthroughs
- embed docs in `agent register` help
- add `doc_printer` callback utility

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68676740a808832490c905fb079962f2