### PR TITLE
Automate CLI docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,26 +5,25 @@ Install the project and run `agentnn --help` to see available commands.
 
 ## Subcommands
 
-| Command | Description |
-|---------|-------------|
-| `agent` | inspect and update agent profiles |
-| `session` | manage and track conversation sessions |
-| `task` | queue utilities and task helpers |
-| `queue` | inspect dispatcher queue |
-| `model` | list and switch language models |
-| `context` | export stored context data and context maps |
-| `prompt` | refine prompts and check quality |
-| `template` | manage built‑in templates |
-| `quickstart` | start wizards for agents and sessions |
-| `train` | track training progress |
-| `feedback` | record user feedback |
-| `tools` | inspect available plugins |
-| `config` | show effective configuration |
-| `governance` | governance and trust utilities |
-| `dispatch` | low level dispatcher call |
-| `submit` | submit a task with metadata |
-| `ask` | send a quick chat request |
-| `reset` | remove session history and user data |
+| Command | Description | Source |
+|---------|-------------|--------|
+| `agent` | Agent management | [agent.py](../sdk/cli/commands/agent.py) |
+| `context` | Context utilities | [context.py](../sdk/cli/commands/context.py) |
+| `dev` | Developer utilities | [dev.py](../sdk/cli/commands/dev.py) |
+| `feedback` | Feedback utilities | [feedback.py](../sdk/cli/commands/feedback.py) |
+| `prompt` | Prompt utilities | [prompt.py](../sdk/cli/commands/prompt.py) |
+| `quickstart` | Automated setup helpers | [quickstart.py](../sdk/cli/commands/quickstart.py) |
+| `session` | Session utilities | [session.py](../sdk/cli/commands/session.py) |
+| `template` | Manage templates | [template.py](../sdk/cli/commands/template.py) |
+| `tools` | Tool registry | [tools.py](../sdk/cli/commands/tools.py) |
+| `train` | Training management | [train.py](../sdk/cli/commands/train.py) |
+| `ask` | Send a quick task to the dispatcher. | [root.py](../sdk/cli/commands/root.py) |
+| `promote` | Promote a queued task by id. | [root.py](../sdk/cli/commands/root.py) |
+| `rate` | Submit a peer rating. | [root.py](../sdk/cli/commands/root.py) |
+| `reset` | Delete session history and user configuration. | [root.py](../sdk/cli/commands/root.py) |
+| `sessions` | List active sessions. | [root.py](../sdk/cli/commands/root.py) |
+| `submit` | Submit a task to the dispatcher. | [root.py](../sdk/cli/commands/root.py) |
+| `verify` | Verify the signature of a ModelContext JSON file. | [root.py](../sdk/cli/commands/root.py) |
 
 ## Examples
 
@@ -162,4 +161,3 @@ verwendet werden. Das Flag `--complete` ergänzt fehlende Felder automatisch.
 - `--preset` lädt gespeicherte Einstellungen aus `~/.agentnn/presets/`.
 - `--last` nutzt die zuletzt verwendete Vorlage erneut.
 - Abgebrochene Wizards lassen sich jederzeit neu starten.
-

--- a/docs/cli_dev.md
+++ b/docs/cli_dev.md
@@ -41,3 +41,15 @@ agentnn example hello --name Alice
 ```
 
 Weitere Beispiele befinden sich in `docs/cli.md`.
+
+## 🛠 CLI-Dokumentation automatisieren mit `agentnn dev docgen`
+
+Die Referenztabelle in `docs/cli.md` lässt sich automatisch aus dem Code
+generieren. Führe dazu folgenden Befehl im Projektverzeichnis aus:
+
+```bash
+agentnn dev docgen --output docs/cli.md
+```
+
+Der Generator untersucht alle Module unter `sdk/cli/commands/` und aktualisiert
+die Tabelle mit Kommandonamen, Kurzbeschreibung und Quellverweis.

--- a/sdk/cli/commands/dev.py
+++ b/sdk/cli/commands/dev.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from tools.cli_docgen import update_cli_doc
+
+
+dev_app = typer.Typer(name="dev", help="Developer utilities")
+
+
+@dev_app.command("docgen")
+def docgen(output: Path = typer.Option(Path("docs/cli.md"), "--output")) -> None:
+    """Generate CLI reference documentation."""
+    update_cli_doc(output)
+    typer.echo(str(output))
+
+
+__all__ = ["dev_app"]

--- a/sdk/cli/main.py
+++ b/sdk/cli/main.py
@@ -20,6 +20,7 @@ from .commands.context import context_app
 from .commands.prompt import prompt_app
 from .commands.template import template_app
 from .commands.quickstart import quickstart_app
+from .commands.dev import dev_app
 
 app = typer.Typer()
 
@@ -36,6 +37,7 @@ app.add_typer(quickstart_app, name="quickstart")
 app.add_typer(feedback_app, name="feedback")
 app.add_typer(tools_app, name="tools")
 app.add_typer(train_app, name="train")
+app.add_typer(dev_app, name="dev")
 register_tasks(app)
 register_model(app)
 register_config(app)

--- a/tests/docs/test_cli_docgen.py
+++ b/tests/docs/test_cli_docgen.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+import sys
+import types
+
+from typer.testing import CliRunner
+
+import sdk.nn_models as _nn
+
+# stub heavy dependencies
+sys.modules.setdefault(
+    "mcp",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(BaseModel=object, Field=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.session.session_manager", types.SimpleNamespace(SessionManager=object)
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_ws",
+    types.SimpleNamespace(
+        ws_server=types.SimpleNamespace(broadcast=lambda *a, **k: None)
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_server", types.SimpleNamespace(create_app=lambda: None)
+)
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+sys.modules.setdefault("sdk.cli.nn_models", _nn)
+DummySettings = type(
+    "DummySettings",
+    (),
+    {"load": classmethod(lambda cls: cls()), "__init__": lambda self: None},
+)
+sys.modules.setdefault(
+    "sdk.cli.config", types.SimpleNamespace(SDKSettings=DummySettings)
+)
+sys.modules.setdefault(
+    "core.config",
+    types.SimpleNamespace(settings=types.SimpleNamespace(model_dump=lambda: {})),
+)
+
+from tools.cli_docgen import collect_cli_info  # noqa: E402
+from sdk.cli.main import app  # noqa: E402
+
+
+def test_all_commands_documented() -> None:
+    groups, root_cmds = collect_cli_info()
+    documented = {
+        line.split("|")[1].strip().strip("`")
+        for line in Path("docs/cli.md").read_text().splitlines()
+        if line.startswith("| `")
+    }
+    expected = {name for name, _, _ in groups} | {name for name, _, _ in root_cmds}
+    assert expected <= documented
+
+
+def test_cli_help_contains_commands() -> None:
+    groups, _ = collect_cli_info()
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for name, _, _ in groups:
+        assert name in result.stdout

--- a/tools/cli_docgen.py
+++ b/tools/cli_docgen.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+
+Command = Tuple[str, str, Path]
+
+
+def _parse_module(
+    path: Path,
+) -> Tuple[dict[str, Tuple[str, str, Path]], List[Tuple[str, str, Path]]]:
+    """Return Typer groups and root commands found in ``path``."""
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    groups: dict[str, Tuple[str, str, Path]] = {}
+    root_cmds: List[Tuple[str, str, Path]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            func = node.value.func
+            if isinstance(func, ast.Attribute) and func.attr == "Typer":
+                kw = {
+                    k.arg: getattr(k.value, "value", None) for k in node.value.keywords
+                }
+                name = kw.get("name")
+                help_text = kw.get("help", "") or ""
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        groups[target.id] = (name or target.id, help_text, path)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            doc = ast.get_docstring(node) or ""
+            for deco in node.decorator_list:
+                if isinstance(deco, ast.Call) and isinstance(deco.func, ast.Attribute):
+                    if deco.func.attr == "command" and isinstance(
+                        deco.func.value, ast.Name
+                    ):
+                        var = deco.func.value.id
+                        cmd_name = None
+                        if deco.args:
+                            arg = deco.args[0]
+                            if isinstance(arg, ast.Constant):
+                                cmd_name = arg.value
+                        for kw in deco.keywords:
+                            if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                                cmd_name = kw.value.value
+                        if cmd_name is None:
+                            cmd_name = node.name
+                        first_line = doc.splitlines()[0] if doc else ""
+                        if var == "app" and path.name == "root.py":
+                            root_cmds.append((cmd_name, first_line, path))
+                        elif var in groups:
+                            # command belongs to a group; ensure group stored
+                            pass
+    return groups, root_cmds
+
+
+def collect_cli_info() -> Tuple[List[Command], List[Command]]:
+    base = Path("sdk/cli/commands")
+    groups: List[Command] = []
+    root_cmds: List[Command] = []
+    module_groups: dict[str, Tuple[str, str, Path]] = {}
+    for path in sorted(base.glob("*.py")):
+        g, r = _parse_module(path)
+        module_groups.update(g)
+        root_cmds.extend(r)
+
+    main_tree = ast.parse(Path("sdk/cli/main.py").read_text())
+    selected: List[str] = []
+    import_map: dict[str, str] = {}
+    register_map: dict[str, str] = {}
+    for node in main_tree.body:
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module
+            and node.module.endswith(tuple("commands".split()))
+        ):
+            mod = node.module.split(".")[-1]
+            for alias in node.names:
+                name = alias.asname or alias.name
+                if alias.name == "register":
+                    register_map[name] = mod
+                else:
+                    import_map[name] = mod
+    for node in ast.walk(main_tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_typer"
+        ):
+            if node.args and isinstance(node.args[0], ast.Name):
+                selected.append(node.args[0].id)
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in register_map
+        ):
+            mod = register_map[node.func.id]
+            reg_tree = ast.parse(Path(f"sdk/cli/commands/{mod}.py").read_text())
+            for sub in ast.walk(reg_tree):
+                if (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Attribute)
+                    and sub.func.attr == "add_typer"
+                ):
+                    if sub.args and isinstance(sub.args[0], ast.Name):
+                        selected.append(sub.args[0].id)
+
+    for var in selected:
+        if var in module_groups:
+            name, help_text, path = module_groups[var]
+            groups.append((name, help_text, path))
+    # deduplicate root commands
+    root_unique: dict[str, Tuple[str, Path]] = {}
+    for name, help_text, p in root_cmds:
+        root_unique.setdefault(name, (help_text, p))
+    root_cmds = [(n, h, p) for n, (h, p) in root_unique.items()]
+    return groups, root_cmds
+
+
+def generate_table(groups: List[Command], root_cmds: List[Command]) -> List[str]:
+    lines = ["| Command | Description | Source |", "|---------|-------------|--------|"]
+    docs_dir = Path("docs")
+    for name, help_text, path in sorted(groups):
+        rel = Path(os.path.relpath(path, docs_dir))
+        lines.append(f"| `{name}` | {help_text} | [{path.name}]({rel.as_posix()}) |")
+    for name, help_text, path in sorted(root_cmds):
+        rel = Path(os.path.relpath(path, docs_dir))
+        lines.append(f"| `{name}` | {help_text} | [{path.name}]({rel.as_posix()}) |")
+    return lines
+
+
+def update_cli_doc(output: Path) -> None:
+    groups, root_cmds = collect_cli_info()
+    table = generate_table(groups, root_cmds)
+    text = output.read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(text) if line.strip() == "## Subcommands")
+    end = start + 1
+    while end < len(text) and not text[end].startswith("## "):
+        end += 1
+    new_text = text[: start + 1] + ["", *table, ""] + text[end:]
+    output.write_text("\n".join(new_text), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default="docs/cli.md")
+    args = parser.parse_args()
+    update_cli_doc(Path(args.output))


### PR DESCRIPTION
## Summary
- add doc generation script `cli_docgen.py`
- expose new `agentnn dev docgen` command
- update CLI reference table via generator
- document automated docs workflow
- verify docs via new tests

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686769df04dc8324bf031f32be4414ff