### PR TITLE
Implement MCP CLI and endpoints

### DIFF
--- a/agentnn/mcp/context_adapter.py
+++ b/agentnn/mcp/context_adapter.py
@@ -8,7 +8,7 @@ from core.model_context import ModelContext
 
 def to_mcp(ctx: ModelContext) -> dict:
     """Return a plain dictionary representation for MCP payloads."""
-    return ctx.model_dump(exclude_none=True)
+    return ctx.model_dump(mode="json", exclude_none=True)
 
 
 def from_mcp(data: dict | ModelContext) -> ModelContext:

--- a/agentnn/mcp/mcp_server.py
+++ b/agentnn/mcp/mcp_server.py
@@ -8,6 +8,10 @@ from fastapi import APIRouter, FastAPI
 from api_gateway.connectors import ServiceConnector
 from ..storage import context_store
 from ..context import generate_map
+from ..prompting import propose_refinement
+from ..storage import snapshot_store
+from core.voting import ProposalVote, record_vote
+from datetime import datetime
 from ..session.session_manager import SessionManager
 from .mcp_ws import ws_server
 from core.model_context import ModelContext
@@ -76,9 +80,39 @@ def create_app() -> FastAPI:
     async def create_agent(agent: dict) -> dict:
         return await registry.post("/register", agent)
 
+    @router.post("/agent/register")
+    async def agent_register(agent: dict) -> dict:
+        return await registry.post("/register", agent)
+
+    @router.get("/agent/list")
+    async def agent_list() -> list:
+        return await registry.get("/agents")
+
+    @router.get("/agent/info/{name}")
+    async def agent_info(name: str) -> dict:
+        agents = await registry.get("/agents")
+        for a in agents:
+            if a.get("name") == name:
+                return a
+        return {}
+
     @router.post("/tool/use")
     async def use_tool(payload: dict) -> dict:
         return await tools.post("/execute_tool", payload)
+
+    @router.post("/session/start")
+    async def session_start(payload: dict | None = None) -> dict:
+        data = payload or {}
+        return await sessions.post("/session", {"data": data})
+
+    @router.get("/session/status/{sid}")
+    async def session_status_route(sid: str) -> dict:
+        return await sessions.get(f"/session/{sid}/status")
+
+    @router.post("/session/restore/{snapshot_id}")
+    async def session_restore(snapshot_id: str) -> dict:
+        sid = snapshot_store.restore_snapshot(snapshot_id)
+        return {"session_id": sid}
 
     @router.post("/session/create")
     async def create_session_route() -> dict:
@@ -94,6 +128,45 @@ def create_app() -> FastAPI:
     async def run_task_route(sid: str, payload: dict) -> dict:
         ctx = session_pool.run_task(sid, payload.get("task", ""))
         return ctx.model_dump()
+
+    @router.post("/task/ask", response_model=ModelContext)
+    async def task_ask(ctx: ModelContext) -> ModelContext:
+        return await dispatcher.post("/dispatch", ctx.model_dump())
+
+    @router.post("/task/dispatch", response_model=ModelContext)
+    async def task_dispatch(ctx: ModelContext) -> ModelContext:
+        return await dispatcher.post("/dispatch", ctx.model_dump())
+
+    @router.get("/task/result/{task_id}")
+    async def task_result(task_id: str) -> dict:
+        return {"status": "unknown", "task_id": task_id}
+
+    @router.post("/prompt/refine")
+    async def prompt_refine(payload: dict) -> dict:
+        prompt = payload.get("prompt", "")
+        strategy = payload.get("strategy", "direct")
+        return {"refined": propose_refinement(prompt, strategy)}
+
+    @router.post("/train/start")
+    async def train_start_route(payload: dict) -> dict:
+        # minimal stub for training start
+        return {"started": payload.get("agent")}
+
+    @router.post("/feedback/record/{sid}")
+    async def feedback_record(sid: str, payload: dict) -> dict:
+        return await sessions.post(f"/session/{sid}/feedback", payload)
+
+    @router.post("/governance/vote")
+    async def governance_vote(payload: dict) -> dict:
+        vote = ProposalVote(
+            proposal_id=payload.get("proposal_id", "unknown"),
+            agent_id=payload.get("agent_id", "anon"),
+            decision=payload.get("decision", "yes"),
+            comment=payload.get("comment"),
+            created_at=datetime.utcnow().isoformat(),
+        )
+        record_vote(vote)
+        return {"status": "recorded"}
 
     app = FastAPI(title="Agent-NN MCP Server")
     app.include_router(router)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -161,3 +161,13 @@ verwendet werden. Das Flag `--complete` ergänzt fehlende Felder automatisch.
 - `--preset` lädt gespeicherte Einstellungen aus `~/.agentnn/presets/`.
 - `--last` nutzt die zuletzt verwendete Vorlage erneut.
 - Abgebrochene Wizards lassen sich jederzeit neu starten.
+
+## MCP Utilities
+
+The `mcp` subcommand bundles tools for the Model Context Protocol.
+
+```bash
+agentnn mcp serve --port 8090
+agentnn mcp register-endpoint demo http://mcp.example.com
+agentnn mcp invoke demo.text-analyzer --input '{"text": "Hi"}'
+```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -38,3 +38,35 @@ curl -X POST http://localhost:9000/v1/mcp/execute \
      -H "Content-Type: application/json" \
      -d '{"task_context": {"task_type": "chat", "description": "Hello"}}'
 ```
+
+## Additional Endpoints
+
+The server now exposes further MCP routes to control the system:
+
+- `POST /v1/mcp/agent/register` – register an agent
+- `GET /v1/mcp/agent/list` – list all agents
+- `GET /v1/mcp/agent/info/{name}` – details for one agent
+- `POST /v1/mcp/session/start` – create a session
+- `GET /v1/mcp/session/status/{id}` – session status
+- `POST /v1/mcp/session/restore/{snapshot}` – restore from snapshot
+- `POST /v1/mcp/task/dispatch` – dispatch a task
+- `POST /v1/mcp/task/ask` – simplified alias for dispatch
+- `POST /v1/mcp/prompt/refine` – refine a prompt
+- `GET /v1/mcp/context/map` – context map of stored sessions
+
+Start the server with:
+
+```bash
+agentnn mcp serve --host 0.0.0.0 --port 8090
+```
+
+### Using external MCP tools
+
+Register remote endpoints and invoke tools directly:
+
+```bash
+agentnn mcp register-endpoint demo http://mcp.example.com
+agentnn mcp invoke demo.text-analyzer --input '{"text": "hello"}'
+```
+
+Agents can reference tools via `mcp://` URLs in their configuration.

--- a/sdk/cli/commands/mcp.py
+++ b/sdk/cli/commands/mcp.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import typer
+
+from core.run_service import run_service
+from agentnn.mcp.mcp_server import create_app
+
+mcp_app = typer.Typer(name="mcp", help="MCP utilities")
+
+_CONFIG = Path.home() / ".agentnn" / "mcp_endpoints.json"
+
+
+def _load() -> dict[str, str]:
+    if _CONFIG.exists():
+        try:
+            return json.loads(_CONFIG.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def _save(data: dict[str, str]) -> None:
+    _CONFIG.parent.mkdir(parents=True, exist_ok=True)
+    _CONFIG.write_text(json.dumps(data, indent=2))
+
+
+@mcp_app.command("serve")
+def serve(host: str = "0.0.0.0", port: int = 8090) -> None:
+    """Start the MCP server."""
+    app = create_app()
+    run_service(app, host=host, port=port)
+
+
+@mcp_app.command("register-endpoint")
+def register_endpoint(alias: str, url: str) -> None:
+    """Store alias and URL for a remote MCP server."""
+    data = _load()
+    data[alias] = url.rstrip("/")
+    _save(data)
+    typer.echo(f"registered {alias}")
+
+
+@mcp_app.command("invoke")
+def invoke(target: str, input: str = typer.Option("{}", "--input")) -> None:
+    """Invoke TOOL_ID on endpoint alias with JSON input."""
+    if "." not in target:
+        typer.echo("invalid target")
+        raise typer.Exit(1)
+    alias, tool_id = target.split(".", 1)
+    data = _load()
+    if alias not in data:
+        typer.echo("unknown endpoint")
+        raise typer.Exit(1)
+    url = f"{data[alias]}/v1/mcp/{tool_id}"
+    payload = json.loads(input)
+    resp = httpx.post(url, json=payload, timeout=10)
+    resp.raise_for_status()
+    typer.echo(resp.text)
+
+
+__all__ = ["mcp_app"]

--- a/sdk/cli/main.py
+++ b/sdk/cli/main.py
@@ -21,6 +21,7 @@ from .commands.prompt import prompt_app
 from .commands.template import template_app
 from .commands.quickstart import quickstart_app
 from .commands.dev import dev_app
+from .commands.mcp import mcp_app
 
 app = typer.Typer()
 
@@ -38,6 +39,7 @@ app.add_typer(feedback_app, name="feedback")
 app.add_typer(tools_app, name="tools")
 app.add_typer(train_app, name="train")
 app.add_typer(dev_app, name="dev")
+app.add_typer(mcp_app, name="mcp")
 register_tasks(app)
 register_model(app)
 register_config(app)

--- a/tests/mcp/test_agent_external_tools.py
+++ b/tests/mcp/test_agent_external_tools.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import types
+import httpx
+from typer.testing import CliRunner
+import pytest
+import sys
+
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+sys.modules.setdefault(
+    "agentnn.session.session_manager",
+    types.SimpleNamespace(SessionManager=object),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_ws",
+    types.SimpleNamespace(ws_server=types.SimpleNamespace(broadcast=lambda *a, **k: None)),
+)
+sys.modules.setdefault(
+    "agentnn.mcp.mcp_server",
+    types.SimpleNamespace(create_app=lambda: None),
+)
+import sdk.nn_models as _nn  # noqa: E402
+sys.modules.setdefault("sdk.cli.nn_models", _nn)
+sys.modules.setdefault(
+    "core.config", types.SimpleNamespace(settings=types.SimpleNamespace(model_dump=lambda: {}))
+)
+sys.modules.setdefault("jsonschema", types.SimpleNamespace(validate=lambda *a, **k: None))
+
+from sdk.cli.main import app  # noqa: E402
+
+
+@pytest.mark.unit
+def test_register_and_invoke(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    import sdk.cli.commands.mcp as mcp_cmd
+    mcp_cmd._CONFIG = home / ".agentnn" / "mcp_endpoints.json"
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda url, json, timeout=10: types.SimpleNamespace(
+            status_code=200,
+            text="ok",
+            json=lambda: {"ok": True},
+            raise_for_status=lambda: None,
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["mcp", "register-endpoint", "demo", "http://example.com"])
+    assert result.exit_code == 0
+    file = home / ".agentnn" / "mcp_endpoints.json"
+    assert file.exists()
+
+    result = runner.invoke(app, ["mcp", "invoke", "demo.test", "--input", "{}"])
+    assert result.exit_code == 0

--- a/tests/mcp/test_client_interaction.py
+++ b/tests/mcp/test_client_interaction.py
@@ -1,0 +1,52 @@
+from fastapi.testclient import TestClient
+import pytest
+import sys
+import types
+
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+
+from agentnn.mcp import mcp_server  # noqa: E402
+from agentnn.mcp.mcp_client import MCPClient  # noqa: E402
+from core.model_context import ModelContext, TaskContext  # noqa: E402
+
+
+class DummyConnector:
+    def __init__(self, *a, **k):
+        pass
+
+    async def get(self, *a, **k):
+        return {}
+
+    async def post(self, *a, **k):
+        return {}
+
+
+@pytest.mark.unit
+def test_client_exec(monkeypatch):
+    monkeypatch.setattr(mcp_server, "ServiceConnector", DummyConnector)
+    app = mcp_server.create_app()
+    client = TestClient(app)
+    mcp = MCPClient("http://testserver")
+    mcp._client = client  # type: ignore
+
+    ctx = ModelContext(task_context=TaskContext(task_type="chat", description="hi"))
+    result = mcp.execute(ctx)
+    assert isinstance(result, ModelContext)

--- a/tests/mcp/test_server_exposure.py
+++ b/tests/mcp/test_server_exposure.py
@@ -1,0 +1,49 @@
+from fastapi.testclient import TestClient
+import pytest
+import sys
+import types
+
+sys.modules.setdefault(
+    "mlflow",
+    types.SimpleNamespace(
+        start_run=lambda *a, **k: None,
+        set_tag=lambda *a, **k: None,
+        log_param=lambda *a, **k: None,
+        log_metric=lambda *a, **k: None,
+        set_tracking_uri=lambda *a, **k: None,
+        tracking=types.SimpleNamespace(
+            MlflowClient=lambda: types.SimpleNamespace(
+                list_experiments=lambda: [],
+                get_run=lambda run_id: types.SimpleNamespace(
+                    info=types.SimpleNamespace(run_id=run_id, status="FINISHED"),
+                    data=types.SimpleNamespace(metrics={}, params={}),
+                ),
+            )
+        ),
+    ),
+)
+
+from agentnn.mcp import mcp_server  # noqa: E402
+
+
+class DummyConnector:
+    def __init__(self, *a, **k):
+        pass
+
+    async def get(self, path: str):
+        if path == "/agents":
+            return []
+        return {}
+
+    async def post(self, *a, **k):
+        return {}
+
+
+@pytest.mark.unit
+def test_server_routes(monkeypatch):
+    monkeypatch.setattr(mcp_server, "ServiceConnector", DummyConnector)
+    app = mcp_server.create_app()
+    client = TestClient(app)
+    assert client.get("/v1/mcp/ping").status_code == 200
+    assert client.get("/v1/mcp/context/map").status_code == 200
+    assert client.get("/v1/mcp/agent/list").status_code == 200


### PR DESCRIPTION
## Summary
- add `mcp` command group with `serve`, `register-endpoint`, and `invoke`
- expose additional MCP routes such as agent registration and session control
- fix MCP context adapter JSON export
- document new CLI usage and MCP endpoints
- add basic MCP integration tests

## Testing
- `ruff check agentnn/mcp/mcp_server.py agentnn/mcp/context_adapter.py sdk/cli/commands/mcp.py tests/mcp/*.py`
- `mypy mcp`
- `pytest tests/mcp/test_server_exposure.py tests/mcp/test_client_interaction.py tests/mcp/test_agent_external_tools.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68676e02bc2c83249d0717a38d2f2c49