### PR TITLE
Add docs and tests for managers

### DIFF
--- a/docs/dev_managers.md
+++ b/docs/dev_managers.md
@@ -1,0 +1,16 @@
+# Manager-Übersicht
+
+Dieser Abschnitt gibt eine kurze Übersicht über die wichtigsten Manager im Projekt.
+
+| Manager | Zweck |
+|---------|------|
+| `AgentManager` | Verwaltet alle WorkerAgents und wählt anhand eines HybridMatchers den passenden Agenten. |
+| `EnhancedAgentManager` | Kombiniert AgentOptimizer und NNManager für kontinuierliche Leistungsverbesserung. |
+| `AgentOptimizer` | Analysiert Metriken und optimiert Agent-Konfigurationen. |
+| `CommunicationManager` | Kümmert sich um die asynchrone Nachrichtenübertragung zwischen Agenten. |
+| `ModelManager` | Lädt und registriert verfügbare Modelle. |
+| `ModelRegistry` | Versioniert Modelle und speichert Metadaten. |
+| `SecurityManager` | Implementiert grundlegende Authentifizierungs- und Prüfmechanismen. |
+| `SystemManager` | Übernimmt Systemaufgaben wie Ressourcenprüfung und Wartung. |
+
+Weitere Manager finden sich im Verzeichnis `managers/` und kapseln jeweils ihren Funktionsbereich. Detaillierte Informationen sind in der Code-Dokumentation zu finden.

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,11 @@
+# Modellübersicht
+
+Die neuronalen Modelle befinden sich im Ordner `nn_models/`.
+
+| Modelldatei | Beschreibung |
+|-------------|-------------|
+| `agent_nn.py` | Enthält das Kernnetz zur Bewertung von Aufgaben und zur Generierung von Feature-Vektoren. |
+| `model_init.py` | Stellt Hilfsfunktionen bereit, um Modelle zu initialisieren oder zu laden. |
+| `meta_learner.py` | Implementiert ein einfaches Meta-Lernverfahren zur Agentenbewertung. |
+
+Modelle können über den `ModelManager` geladen und anschließend als Tools registriert werden. Eigene Modelle lassen sich durch Ableiten der Basisklassen einbinden und über die Konfigurationsdateien aktivieren.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,8 @@ nav:
     - Nx Python Plugin: development/nxlv-python.md
     - Release Notes: development/releases.md
     - Release Checklist: release_checklist.md
+    - Manager-Übersicht: dev_managers.md
+    - Modelle: models.md
   - Deployment:
     - Docker: deployment/docker.md
     - Kubernetes: deployment/kubernetes.md

--- a/tests/test_agent_optimizer.py
+++ b/tests/test_agent_optimizer.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import asyncio
+from datetime import datetime
+
+from managers.agent_optimizer import AgentOptimizer
+
+class TestAgentOptimizer(unittest.TestCase):
+    def setUp(self):
+        self.mlflow_patcher = patch('managers.agent_optimizer.mlflow')
+        self.mock_mlflow = self.mlflow_patcher.start()
+        self.mock_mlflow.set_experiment.return_value = MagicMock(experiment_id="exp")
+
+        self.embed_patcher = patch('managers.agent_optimizer.OpenAIEmbeddings')
+        self.mock_embed_cls = self.embed_patcher.start()
+        self.mock_embed = MagicMock()
+        self.mock_embed.embed_query.return_value = [0.1, 0.2, 0.3]
+        self.mock_embed_cls.return_value = self.mock_embed
+
+        self.chroma_patcher = patch('managers.agent_optimizer.Chroma')
+        self.mock_chroma_cls = self.chroma_patcher.start()
+        self.mock_chroma = MagicMock()
+        self.mock_chroma.similarity_search_with_score.return_value = [(
+            MagicMock(metadata={'domain': 'finance'}), 0.9
+        )]
+        self.mock_chroma.similarity_search.return_value = []
+        self.mock_chroma_cls.return_value = self.mock_chroma
+
+        self.optimizer = AgentOptimizer()
+
+    def tearDown(self):
+        self.mlflow_patcher.stop()
+        self.embed_patcher.stop()
+        self.chroma_patcher.stop()
+
+    def test_evaluate_agent_without_metrics(self):
+        result = asyncio.run(self.optimizer.evaluate_agent('a1'))
+        self.assertEqual(result['status'], 'unknown')
+        self.assertTrue(result['needs_optimization'])
+
+    def test_get_agent_performance_trend(self):
+        now = datetime.now().isoformat()
+        self.optimizer.agent_metrics['a1'] = [
+            {'response_quality': 0.8, 'task_success': True, 'user_satisfaction': 0.9, 'timestamp': now},
+            {'response_quality': 0.6, 'task_success': False, 'user_satisfaction': 0.7, 'timestamp': now},
+        ]
+        trend = self.optimizer.get_agent_performance_trend('a1', days=1)
+        self.assertAlmostEqual(trend['success_rate'][0], 0.5)
+
+    def test_determine_domain(self):
+        domain, score = asyncio.run(self.optimizer.determine_domain('desc', ['cap']))
+        self.assertEqual(domain, 'finance')
+        self.assertGreater(score, 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- document core managers in docs/dev_managers.md
- add neural model overview in docs/models.md
- include docs in mkdocs navigation
- add missing tests for `AgentOptimizer`

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest -q tests/test_agent_optimizer.py::TestAgentOptimizer::test_evaluate_agent_without_metrics -s` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6867737885b08324aa2b75b0f0bc3e72