### PR TITLE
Enable nn_models via built-in ToolRegistry

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -162,6 +162,20 @@ verwendet werden. Das Flag `--complete` ergänzt fehlende Felder automatisch.
 - `--last` nutzt die zuletzt verwendete Vorlage erneut.
 - Abgebrochene Wizards lassen sich jederzeit neu starten.
 
+## Tool Registry
+
+Builtin model wrappers are included in the `tools` list. Show all tools with:
+
+```bash
+agentnn tools list
+```
+
+Inspect a specific tool:
+
+```bash
+agentnn tools inspect agent_nn_v2
+```
+
 ## MCP Utilities
 
 The `mcp` subcommand bundles tools for the Model Context Protocol.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,19 @@
+# Builtin Tools and Models
+
+Agent-NN ships with a small set of builtin tools. They can be managed via the `agentnn tools` commands.
+
+## Listing Tools
+
+```bash
+agentnn tools list
+```
+
+The output shows plugin based tools and builtin model wrappers.
+
+## Inspecting a Tool
+
+```bash
+agentnn tools inspect agent_nn_v2
+```
+
+This prints the Python class used for the tool. Builtin models such as `agent_nn_v2` and the multi task reasoner can be referenced from agent configurations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
     - Agent Manager: components/agent-manager.md
     - Worker Agents: components/worker-agents.md
     - Neural Models: components/neural-models.md
+    - Tools: tools.md
     - Vector Store: components/vector-store.md
     - MCP Server: mcp.md
     - Session Management: sessions.md

--- a/sdk/cli/commands/tools.py
+++ b/sdk/cli/commands/tools.py
@@ -4,15 +4,20 @@ import json
 import typer
 
 from plugins.loader import PluginManager
+from tools import ToolRegistry
 
 tools_app = typer.Typer(name="tools", help="Tool registry")
 
 
 @tools_app.command("list")
 def tools_list() -> None:
-    """List available tool plugins."""
+    """List available plugins and builtin tools."""
     mgr = PluginManager()
-    typer.echo(json.dumps(mgr.list_plugins(), indent=2))
+    result = {
+        "plugins": mgr.list_plugins(),
+        "builtin": ToolRegistry.list_tools(),
+    }
+    typer.echo(json.dumps(result, indent=2))
 
 
 @tools_app.command("inspect")
@@ -20,7 +25,11 @@ def tools_inspect(name: str) -> None:
     """Show details for ``name``."""
     mgr = PluginManager()
     plugin = mgr.get(name)
-    if not plugin:
+    if plugin:
+        typer.echo(plugin.__class__.__name__)
+        return
+    tool = ToolRegistry.get(name)
+    if not tool:
         typer.echo("not found")
         raise typer.Exit(1)
-    typer.echo(plugin.__class__.__name__)
+    typer.echo(tool.__class__.__name__)

--- a/tests/cli/test_model_tools_cli.py
+++ b/tests/cli/test_model_tools_cli.py
@@ -1,0 +1,23 @@
+from typer.testing import CliRunner
+
+from sdk.cli.main import app
+from tools import registry as registry_mod
+
+
+def test_cli_tools_list_builtin(monkeypatch):
+    from sdk.cli.commands import tools as tools_cmd
+
+    class DummyMgr:
+        def list_plugins(self):
+            return []
+
+        def get(self, name):
+            return None
+
+    monkeypatch.setattr(tools_cmd, "PluginManager", lambda: DummyMgr())
+    monkeypatch.setattr(registry_mod.ToolRegistry, "list_tools", classmethod(lambda cls: ["agent_nn_v2"]))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["tools", "list"])
+    assert result.exit_code == 0
+    assert "agent_nn_v2" in result.stdout

--- a/tests/tools/test_model_wrappers.py
+++ b/tests/tools/test_model_wrappers.py
@@ -1,0 +1,12 @@
+from tools import ToolRegistry
+from tools.model_wrappers import MultiTaskModelWrapper, AgentV2Wrapper
+
+
+def test_registry_register_and_get():
+    ToolRegistry._registry.clear()
+    ToolRegistry.register("mtl", MultiTaskModelWrapper)
+    ToolRegistry.register("v2", AgentV2Wrapper)
+    assert set(ToolRegistry.list_tools()) == {"mtl", "v2"}
+    tool = ToolRegistry.get("mtl")
+    assert isinstance(tool, MultiTaskModelWrapper)
+    assert isinstance(tool.run({}), dict)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,7 @@
+from .registry import ToolRegistry
+from .model_wrappers import MultiTaskModelWrapper, AgentV2Wrapper
+
+ToolRegistry.register("multi_task_reasoner", MultiTaskModelWrapper)
+ToolRegistry.register("agent_nn_v2", AgentV2Wrapper)
+
+__all__ = ["ToolRegistry", "MultiTaskModelWrapper", "AgentV2Wrapper"]

--- a/tools/model_wrappers.py
+++ b/tools/model_wrappers.py
@@ -1,0 +1,61 @@
+"""Simple wrappers exposing nn_models via a unified interface."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def _torch_available() -> bool:
+    try:  # pragma: no cover - optional dependency
+        import importlib.util
+
+        return importlib.util.find_spec("torch") is not None
+    except Exception:  # pragma: no cover - importlib failure
+        return False
+
+
+class BaseModelTool:
+    """Base interface for model tools."""
+
+    description: str = ""
+    parameters: Dict[str, Any] = {}
+    input_schema: Dict[str, Any] = {}
+
+    def run(self, input: Dict[str, Any]) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+class MultiTaskModelWrapper(BaseModelTool):
+    """Wrapper for ``nn_models.multi_task_learning``."""
+
+    description = "Multi-task learning model"
+
+    def run(self, input: Dict[str, Any]) -> Dict[str, Any]:  # pragma: no cover - optional torch
+        if not _torch_available():
+            return {"error": "torch not installed"}
+        from nn_models.multi_task_learning import TaskEncoder
+        import torch
+
+        model = TaskEncoder(input_dim=4, hidden_dims=[4], output_dim=2)
+        x = torch.zeros(1, 4)
+        with torch.no_grad():
+            out = model(x)
+        return {"output": out.tolist()}
+
+
+class AgentV2Wrapper(BaseModelTool):
+    """Wrapper for ``nn_models.agent_nn_v2``."""
+
+    description = "AgentNN v2 model"
+
+    def run(self, input: Dict[str, Any]) -> Dict[str, Any]:  # pragma: no cover - optional torch
+        if not _torch_available():
+            return {"error": "torch not installed"}
+        from nn_models.agent_nn_v2 import AgentNN
+        import torch
+
+        model = AgentNN()
+        x = torch.zeros(1, 768)
+        with torch.no_grad():
+            out = model(x)
+        return {"output": out.tolist()}

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -1,0 +1,24 @@
+"""Lightweight in-memory registry for builtin tools."""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+
+
+class ToolRegistry:
+    """Register and instantiate tool wrappers."""
+
+    _registry: Dict[str, Type] = {}
+
+    @classmethod
+    def register(cls, name: str, tool_cls: Type) -> None:
+        cls._registry[name] = tool_cls
+
+    @classmethod
+    def get(cls, name: str):
+        tool_cls = cls._registry.get(name)
+        return tool_cls() if tool_cls else None
+
+    @classmethod
+    def list_tools(cls) -> list[str]:
+        return list(cls._registry.keys())


### PR DESCRIPTION
## Summary
- register multi task reasoner and agent_nn_v2 as builtin tools
- expose ToolRegistry through CLI
- document usage of built-in tools
- include new docs page and mkdocs navigation
- add unit tests for registry and CLI integration

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686779fef164832486651a094417a977