### PR TITLE
Fix deployment scripts and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Aktuelle Version: **v1.0.3** – Flowise-Export und Dokumentation aktualisiert.
 
 ## Systemvoraussetzungen
 
-- Python 3.9 oder neuer
+- Python 3.10 oder neuer
+- Node.js 18+
+- Docker und Docker Compose
+- Poetry 1.5+
 - Mindestens 4 GB RAM
 
 ## Komponentenübersicht
@@ -43,24 +46,11 @@ graph TD
    git clone https://github.com/EcoSphereNetwork/Agent-NN.git
    cd Agent-NN
    ```
-2. Abhängigkeiten mit Poetry installieren und Beispielkonfiguration kopieren
+2. One-Line-Setup ausführen
    ```bash
-   poetry install
-   cp .env.example .env
+   ./scripts/setup.sh
    ```
-3. (Optional) Lokale Modelle herunterladen
-   ```bash
-   python scripts/setup_local_models.py --model all
-   ```
-4. Frontend bauen
-   ```bash
-   ./scripts/deploy/build_frontend.sh
-   ```
-5. Dienste starten
-   ```bash
-   ./scripts/deploy/start_services.sh
-   ```
-6. Erste Anfrage stellen oder UI öffnen
+3. Erste Anfrage stellen oder UI öffnen
    ```bash
    curl -X POST http://localhost:8000/task -H "Content-Type: application/json" \
      -d '{"task_type": "chat", "input": "Hallo"}'
@@ -83,6 +73,7 @@ docker compose up --build
 | `scripts/build_and_test.sh` | Erstellt ein Docker-Image und führt Tests aus |
 | `scripts/deploy_to_registry.sh` | Publiziert Images in ein Container-Registry |
 | `scripts/start_mcp.sh` | Startet das Microservice-Compose-Setup |
+| `scripts/setup.sh` | Komplettes Setup in einem Schritt |
 
 ## Poetry-Workflow
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,0 +1,14 @@
+# Script Übersicht
+
+Dieser Abschnitt beschreibt die wichtigsten Shell-Skripte unter `scripts/`.
+
+| Skript | Zweck | Beispiel |
+|---|---|---|
+| `scripts/setup.sh` | Komplettes Setup ausführen | `./scripts/setup.sh` |
+| `scripts/deploy/build_frontend.sh` | React-Frontend bauen | `./scripts/deploy/build_frontend.sh --clean` |
+| `scripts/deploy/start_services.sh` | Docker-Services starten | `./scripts/deploy/start_services.sh --build` |
+| `scripts/deploy/dev_reset.sh` | Entwicklungsumgebung zurücksetzen | `./scripts/deploy/dev_reset.sh` |
+| `scripts/build_and_test.sh` | Docker-Image bauen und Tests ausführen | `./scripts/build_and_test.sh` |
+
+Alle Skripte geben im Fehlerfall einen Exit-Code ungleich Null zurück und unterstützen die Option `--help` für eine Kurzbeschreibung.
+

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,53 @@
+# Setup Guide
+
+Dieser Leitfaden beschreibt die Installation von Agent-NN Schritt für Schritt.
+
+## Vorbereitung
+
+* Node.js 18+
+* Docker mit Docker Compose
+* Python 3.10+
+* [Poetry](https://python-poetry.org/)
+
+Kopiere die Datei `.env.example` zu `.env` und passe Werte wie Ports oder Tokens an.
+
+## Python / Poetry
+
+```bash
+poetry install
+```
+
+Die CLI steht anschließend über `poetry run agentnn` bereit.
+
+## Frontend bauen
+
+```bash
+./scripts/deploy/build_frontend.sh
+```
+
+Die statischen Dateien landen in `frontend/dist/`.
+
+## Dienste starten
+
+```bash
+./scripts/deploy/start_services.sh --build
+```
+
+Die Container laufen im Hintergrund. Beende sie mit `docker compose down`.
+
+### Docker Compose vs. lokal
+
+Alle Services lassen sich auch direkt mit `docker compose up` starten. Für eine rein lokale Ausführung müssen Redis und Postgres installiert sein.
+
+## Umgebungsvariablen
+
+Alle benötigten Variablen sind in `.env.example` dokumentiert. Kopiere diese Datei nach `.env` und passe sie an deine Umgebung an.
+
+## FAQ
+
+**Fehler `unknown flag: -d`**
+: Stelle sicher, dass `docker compose` statt `docker` verwendet wird und deine Docker-Version aktuell ist.
+
+**Ports bereits belegt**
+: Passe die Ports in `.env` an oder stoppe den blockierenden Dienst.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,8 @@ nav:
     - Installation: getting-started/installation.md
     - Quick Start: getting-started/quickstart.md
     - Configuration: getting-started/configuration.md
+  - Setup Guide: setup.md
+  - Scripts: scripts.md
   - Core Concepts:
     - Architecture: concepts/architecture.md
     - Multi-Agent Execution: architecture/multi_agent.md

--- a/scripts/deploy/build_frontend.sh
+++ b/scripts/deploy/build_frontend.sh
@@ -4,10 +4,17 @@
 # Copies are skipped if Vite already builds into the target directory.
 # Pass --clean to remove the dist folder before building.
 
-set -e
+set -eu
+
+usage() {
+    echo "Usage: $(basename "$0") [--clean]" >&2
+}
 
 CLEAN=false
-if [ "$1" = "--clean" ]; then
+if [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
+elif [ "${1:-}" = "--clean" ]; then
     CLEAN=true
 fi
 
@@ -15,6 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")/.."
 FRONTEND_DIR="$REPO_ROOT/frontend/agent-ui"
 DIST_DIR="$REPO_ROOT/frontend/dist"
+echo "Building frontend in $FRONTEND_DIR"
 cd "$FRONTEND_DIR"
 
 if [ ! -f package.json ]; then

--- a/scripts/deploy/dev_reset.sh
+++ b/scripts/deploy/dev_reset.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env sh
 # Reset development environment: remove volumes, sessions and mocks
 
-set -e
+set -eu
+
+usage() {
+    echo "Usage: $(basename "$0")" >&2
+}
+
+if [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")/.."
 cd "$REPO_ROOT"
+echo "Cleaning development environment"
 
 VOLS="postgres_data chroma_data"
 for v in $VOLS; do

--- a/scripts/deploy/start_services.sh
+++ b/scripts/deploy/start_services.sh
@@ -1,7 +1,33 @@
 #!/usr/bin/env sh
 # Start all Docker services with basic health and environment checks
 
-set -e
+set -eu
+
+usage() {
+    echo "Usage: $(basename "$0") [--build] [--dry-run]" >&2
+}
+
+BUILD=false
+DRY=false
+for arg in "$@"; do
+    case $arg in
+        --help)
+            usage
+            exit 0
+            ;;
+        --build)
+            BUILD=true
+            ;;
+        --dry-run)
+            DRY=true
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")/.."
@@ -25,7 +51,14 @@ check_port() {
 check_port 8000
 check_port 3000
 
-docker compose up -d
+CMD="docker compose up -d"
+if $BUILD; then
+    CMD="docker compose up --build -d"
+fi
+echo "Running: $CMD"
+if ! $DRY; then
+    eval "$CMD"
+fi
 
 echo "Services started"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# One-click setup: install dependencies, build frontend and start services
+set -eu
+
+usage() {
+    echo "Usage: $(basename "$0") [--no-services]" >&2
+}
+
+NO_SERVICES=false
+for arg in "$@"; do
+    case $arg in
+        --help)
+            usage
+            exit 0
+            ;;
+        --no-services)
+            NO_SERVICES=true
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+poetry install
+scripts/deploy/build_frontend.sh
+if ! $NO_SERVICES; then
+    scripts/deploy/start_services.sh --build
+fi
+
+echo "Setup complete"

--- a/tests/scripts/test_scripts.sh
+++ b/tests/scripts/test_scripts.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPTS="scripts/deploy/build_frontend.sh scripts/deploy/start_services.sh scripts/deploy/dev_reset.sh scripts/setup.sh"
+for s in $SCRIPTS; do
+    echo "Testing $s"
+    ./$s --help >/dev/null
+done
+
+echo "All script help commands succeeded"


### PR DESCRIPTION
## Summary
- unify deployment scripts with help messages and docker compose usage
- provide `setup.sh` for easy local installation
- document installation steps and script overview
- integrate new docs into mkdocs navigation
- add simple shell test for script help commands

## Testing
- `bash tests/scripts/test_scripts.sh`
- `mypy mcp`
- `ruff check . --exit-zero`

------
https://chatgpt.com/codex/tasks/task_e_6867a7ec35fc832499828388458421fa