### PR TITLE
Improve setup scripts with environment checks and docker fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,12 +22,15 @@ LOG_FORMAT=json  # log format
 CACHE_SIZE=1024  # cache entries
 MAX_CONCURRENT_TASKS=10  # max parallel tasks
 TASK_TIMEOUT=300  # task timeout seconds
+TIMEOUT_DEFAULT=30  # default request timeout
+DISABLE_DEV_FEATURES=false  # disable development helpers
 
 # Security
 JWT_SECRET=your_jwt_secret_here  # signing key
 JWT_ALGORITHM=HS256  # JWT algorithm
 JWT_EXPIRATION_MINUTES=1440  # 24 hours
 AUTH_ENABLED=false  # enable auth
+ENABLE_AUTH=false  # alternative auth toggle
 API_TOKENS=abc123  # comma separated tokens
 RATE_LIMITS_ENABLED=true  # enable rate limiting
 RATE_LIMIT_TASK=10/minute  # tasks per minute

--- a/README.md
+++ b/README.md
@@ -155,14 +155,14 @@ providers:
 ## 🤖 Installation (Entwicklung)
 
 ```bash
-git clone https://github.com/EcoSphereNetwork/Agent-NN.git
-cd Agent-NN
-poetry install
-poetry run agentnn --version
+# 1. Abhängigkeiten sicherstellen
+sudo apt install docker docker-compose nodejs npm python3-poetry
 
-# Falls der Installationsschritt scheitert, kann `poetry install --no-root`
-# verwendet werden. Alternativ lässt sich der Paketmodus in der
-# `pyproject.toml` mit `package-mode = false` deaktivieren.
+# 2. Repository klonen
+git clone https://github.com/EcoSphereNetwork/Agent-NN.git && cd Agent-NN
+
+# 3. Setup starten
+./scripts/setup.sh
 ```
 
 ### Empfohlene Umgebung

--- a/scripts/build_frontend.sh
+++ b/scripts/build_frontend.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+# Build React frontend with safety checks
+set -e
+
+log_info() { echo "\033[1;34m[...]\033[0m $1"; }
+log_ok() { echo "\033[1;32m[✓]\033[0m $1"; }
+log_err() { echo "\033[1;31m[✗]\033[0m $1" >&2; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FRONTEND_DIR="$SCRIPT_DIR/../frontend/agent-ui"
+TARGET_DIST="$SCRIPT_DIR/../frontend/dist"
+
+cd "$FRONTEND_DIR"
+
+if [ ! -f package.json ]; then
+  log_err "package.json nicht gefunden"
+  exit 1
+fi
+
+log_info "Installiere Node-Abh\xC3\xA4ngigkeiten"
+npm ci
+
+log_info "Baue Frontend"
+npm run build
+
+OUT_DIR="dist"
+mkdir -p "$TARGET_DIST"
+if [ ! "$(realpath ../dist 2>/dev/null || echo '')" = "$(realpath "$TARGET_DIST")" ]; then
+  if [ ! "$(realpath "$OUT_DIR")" = "$(realpath "$TARGET_DIST")" ]; then
+    cp -r "$OUT_DIR"/* "$TARGET_DIST"/
+  else
+    echo "[skip] source and destination are identical"
+  fi
+else
+  echo "[skip] source and destination are identical"
+fi
+
+log_ok "Frontend gebaut"

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+# Basic environment checks for Agent-NN setup
+set -e
+
+log_info() { echo "\033[1;34m[...]\033[0m $1"; }
+log_ok() { echo "\033[1;32m[✓]\033[0m $1"; }
+log_warn() { echo "\033[1;33m[⚠]\033[0m $1"; }
+log_err() { echo "\033[1;31m[✗]\033[0m $1" >&2; }
+
+# ensure .env file exists
+if [ ! -f ".env" ]; then
+  log_warn ".env-Datei nicht gefunden. Erstelle aus .env.example..."
+  cp .env.example .env
+fi
+
+# check poetry
+if ! command -v poetry >/dev/null 2>&1; then
+  log_err "Poetry nicht installiert"
+  exit 1
+fi
+
+# check node/npm
+if ! command -v node >/dev/null 2>&1; then
+  log_err "Node.js nicht installiert"
+  exit 1
+fi
+if ! command -v npm >/dev/null 2>&1; then
+  log_err "npm nicht installiert"
+  exit 1
+fi
+
+# check docker
+if ! command -v docker >/dev/null 2>&1; then
+  log_err "Docker nicht installiert"
+  exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+  log_err "Docker-Daemon nicht erreichbar"
+  exit 1
+fi
+
+log_ok "Umgebungsprüfungen abgeschlossen"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,68 +1,34 @@
 #!/usr/bin/env sh
-# One-click setup: install dependencies, build frontend and start services
+# Orchestrated setup for Agent-NN
 set -eu
 
 log_info() { echo "\033[1;34m[...]\033[0m $1"; }
 log_ok() { echo "\033[1;32m[✓]\033[0m $1"; }
 log_err() { echo "\033[1;31m[✗]\033[0m $1" >&2; }
 
-usage() {
-    echo "Usage: $(basename "$0") [--no-services]" >&2
-}
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
 
-NO_SERVICES=false
-for arg in "$@"; do
-    case $arg in
-        --help)
-            usage
-            exit 0
-            ;;
-        --no-services)
-            NO_SERVICES=true
-            ;;
-        *)
-            echo "Unknown option: $arg" >&2
-            usage
-            exit 1
-            ;;
-    esac
-done
+log_info "Pr\xC3\xBCfe Umgebung"
+"$SCRIPT_DIR/check_env.sh"
 
 log_info "Installiere Python-Abh\xC3\xA4ngigkeiten"
-if poetry install; then
-    log_ok "Poetry-Install abgeschlossen"
-else
-    log_err "Poetry-Install fehlgeschlagen"
-    exit 1
-fi
+poetry install
+log_ok "Poetry-Install abgeschlossen"
 
-if [ ! -f frontend/dist/index.html ]; then
-    log_info "Baue Frontend"
-    if scripts/deploy/build_frontend.sh; then
-        log_ok "Frontend gebaut"
-    else
-        log_err "Frontend-Build fehlgeschlagen"
-        exit 1
-    fi
-else
-    log_info "Frontend bereits vorhanden"
-fi
+log_info "Baue Frontend"
+"$SCRIPT_DIR/build_frontend.sh"
+log_ok "Frontend gebaut"
 
-if ! $NO_SERVICES; then
-    log_info "Starte Docker-Services"
-    if scripts/deploy/start_services.sh --build; then
-        log_ok "Docker-Services gestartet"
-    else
-        log_err "Docker konnte nicht gestartet werden."
-        exit 1
-    fi
-fi
+log_info "Starte Docker"
+"$SCRIPT_DIR/start_docker.sh"
+log_ok "Docker gestartet"
 
-if ! poetry run agentnn --help >/dev/null 2>&1; then
-    log_err "Agent-NN konnte nicht gestartet werden. Bitte pr\xC3\xBCfe die Python-Abh\xC3\xA4ngigkeiten."
-    exit 1
+if poetry run agentnn --help >/dev/null 2>&1; then
+  log_ok "CLI verf\xC3\xBCgbar unter: poetry run agentnn"
 else
-    log_ok "Agent-NN CLI erfolgreich getestet"
+  log_err "CLI-Test fehlgeschlagen"
+  exit 1
 fi
 
 echo "\033[1;32m[✓]\033[0m Setup abgeschlossen"

--- a/scripts/start_docker.sh
+++ b/scripts/start_docker.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+# Start Docker services with basic checks
+set -e
+
+log_info() { echo "\033[1;34m[...]\033[0m $1"; }
+log_ok() { echo "\033[1;32m[✓]\033[0m $1"; }
+log_warn() { echo "\033[1;33m[⚠]\033[0m $1"; }
+log_err() { echo "\033[1;31m[✗]\033[0m $1" >&2; }
+
+# verify docker
+if ! command -v docker >/dev/null 2>&1; then
+  log_err "Docker nicht installiert"
+  exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+  log_err "Docker-Daemon nicht erreichbar"
+  exit 1
+fi
+
+# ensure .env exists
+if [ ! -f ".env" ]; then
+  log_warn ".env-Datei nicht gefunden. Erstelle aus .env.example..."
+  cp .env.example .env
+fi
+
+log_info "Starte Docker-Services"
+if command -v docker compose >/dev/null 2>&1; then
+  docker compose up --build -d
+elif command -v docker-compose >/dev/null 2>&1; then
+  docker-compose up --build -d
+else
+  log_err "Docker Compose nicht gefunden. Bitte docker-compose installieren."
+  exit 1
+fi
+
+log_ok "Docker gestartet"


### PR DESCRIPTION
## Summary
- add modular scripts for environment check, frontend build and docker start
- unify installation in setup.sh using new helpers
- extend `.env.example` with additional variables
- update README installation guide

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6867b19e577883249a58e83257365bf8