### PR TITLE
Fix compose detection in setup scripts

### DIFF
--- a/scripts/deploy/start_services.sh
+++ b/scripts/deploy/start_services.sh
@@ -105,10 +105,7 @@ main() {
         exit 1
     fi
     
-    if [[ ! -f "$compose_file" ]]; then
-        log_err "Compose-Datei nicht gefunden: $compose_file"
-        exit 1
-    fi
+    compose_file=$(find_compose_file "$compose_file") || exit 1
     
     # Port-Prüfung
     check_ports

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -322,7 +322,11 @@ main() {
     # Docker-Services starten
     if [[ "$START_DOCKER" == "true" ]]; then
         log_info "=== DOCKER-SERVICES ==="
-        if ! docker_compose_up "docker-compose.yml" "--build"; then
+        compose_file=$(find_compose_file "docker-compose.yml") || {
+            log_err "Docker Compose Datei nicht gefunden. Setup abgebrochen."
+            exit 1
+        }
+        if ! docker_compose_up "$compose_file" "--build"; then
             log_err "Start der Docker-Services fehlgeschlagen. Setup abgebrochen."
             exit 1
         fi

--- a/scripts/start_docker.sh
+++ b/scripts/start_docker.sh
@@ -5,4 +5,5 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/helpers/docker.sh"
 
 # Start Docker services using the docker_compose_up function
-docker_compose_up "docker-compose.yml" "--build" "-d"
+compose_file=$(find_compose_file "docker-compose.yml") || exit 1
+docker_compose_up "$compose_file" "--build" "-d"


### PR DESCRIPTION
## Summary
- auto-detect docker compose plugin or classic
- search compose file in common folders before starting
- warn if docker.sock is missing and show container status after startup
- use compose discovery in setup and deployment helpers

## Testing
- `tests/ci_check.sh` *(fails: ruff found style issues)*

------
https://chatgpt.com/codex/tasks/task_e_6867c4bd6d5c8324b53f9f6df97d2696