### PR TITLE
Add missing nginx config

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,43 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Proxy API requests to the FastAPI gateway
+    location /api/ {
+        proxy_pass http://api_gateway:8000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Proxy WebSocket connections
+    location /ws {
+        proxy_pass http://api_gateway:8000/ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+    }
+
+    # Serve static files
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000";
+    }
+
+    error_page 404 /index.html;
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
## Summary
- add nginx.conf for agent-ui container
- ensures proxy routes to `api_gateway` for HTTP and WebSocket traffic

## Testing
- `./tests/ci_check.sh` *(fails: E402 Module level import not at top of file)*

------
https://chatgpt.com/codex/tasks/task_e_68683592e7d8832499df7a69004b13b2