### PR TITLE
Fix Docusaurus docs build

### DIFF
--- a/docs/BenutzerHandbuch/Benutzerhandbuch.md
+++ b/docs/BenutzerHandbuch/Benutzerhandbuch.md
@@ -36,7 +36,7 @@ Agent-NN ist ein intelligentes Assistenzsystem, das unterschiedliche spezialisie
 
 Agent-NN besteht aus mehreren Hauptkomponenten, die zusammenarbeiten, um Ihnen ein leistungsstarkes Assistenzsystem zu bieten.
 
-![Systemarchitektur](systemarchitektur.svg)
+![Systemarchitektur](Systemarchitektur.svg)
 
 ### Hauptkomponenten
 
@@ -50,7 +50,7 @@ Agent-NN besteht aus mehreren Hauptkomponenten, die zusammenarbeiten, um Ihnen e
 
 Agent-NN bietet verschiedene Arten von Agenten, jeder mit einzigartigen Fähigkeiten:
 
-![Agententypen](agententypen.svg)
+![Agententypen](Agententypen.svg)
 
 - **Finanz-Agent**: Experte für Finanzanalyse, Investitionen und Finanzplanung
 - **Tech-Agent**: Spezialist für Softwareentwicklung, Systemarchitektur und technische Problemlösung
@@ -83,13 +83,13 @@ Agent-NN ist eine webbasierte Anwendung und erfordert keine lokale Installation.
 3. Füllen Sie Ihr Profil aus, um personalisierte Empfehlungen zu erhalten
 4. Konfigurieren Sie Ihre bevorzugten Domänen und Interessen
 
-![Anmeldeprozess](login-process-svg)
+![Anmeldeprozess](Anmeldeprozess.svg)
 
 ## Die Benutzeroberfläche
 
 Die Agent-NN-Benutzeroberfläche ist intuitiv und benutzerfreundlich gestaltet, mit klaren Navigationselementen und einem zentralen Chat-Interface.
 
-![Benutzeroberfläche](ui-overview-svg)
+![Benutzeroberfläche](Benutzeroberfläche.svg)
 
 ### Hauptelemente
 
@@ -119,7 +119,7 @@ Die Interaktion mit Agent-NN erfolgt hauptsächlich über natürlichsprachliche 
 2. Klicken Sie auf "Neue Konversation" oder verwenden Sie die Tastenkombination Ctrl+N/Cmd+N
 3. Beginnen Sie mit einer Nachricht an das System
 
-![Chat-Interaktion](chat-interaction-svg)
+![Chat-Interaktion](Chat-Interaktion.svg)
 
 ### Direkte Agentenwahl
 
@@ -137,7 +137,7 @@ Agent-NN kann komplexe Aufgaben ausführen:
 3. Der Supervisor-Agent analysiert Ihre Anfrage und delegiert sie an den passenden Spezialisten
 4. Bei Bedarf können Agenten Rückfragen stellen oder Klarstellungen erbitten
 
-![Aufgabendelegation](task-delegation-svg)
+![Aufgabendelegation](Aufgabendelegation.svg)
 
 ### Multi-Agent-Zusammenarbeit
 
@@ -189,7 +189,7 @@ Agent-NN ist ein intelligentes Assistenzsystem, das unterschiedliche spezialisie
 
 Agent-NN besteht aus mehreren Hauptkomponenten, die zusammenarbeiten, um Ihnen ein leistungsstarkes Assistenzsystem zu bieten.
 
-![Systemarchitektur](system_architecture.png)
+![Systemarchitektur](Systemarchitektur.svg)
 
 ### Hauptkomponenten
 
@@ -203,7 +203,7 @@ Agent-NN besteht aus mehreren Hauptkomponenten, die zusammenarbeiten, um Ihnen e
 
 Agent-NN bietet verschiedene Arten von Agenten, jeder mit einzigartigen Fähigkeiten:
 
-![Agententypen](agent_types.png)
+![Agententypen](Agententypen.svg)
 
 - **Finanz-Agent**: Experte für Finanzanalyse, Investitionen und Finanzplanung
 - **Tech-Agent**: Spezialist für Softwareentwicklung, Systemarchitektur und technische Problemlösung
@@ -236,13 +236,13 @@ Agent-NN ist eine webbasierte Anwendung und erfordert keine lokale Installation.
 3. Füllen Sie Ihr Profil aus, um personalisierte Empfehlungen zu erhalten
 4. Konfigurieren Sie Ihre bevorzugten Domänen und Interessen
 
-![Anmeldeprozess](login_process.png)
+![Anmeldeprozess](Anmeldeprozess.svg)
 
 ## Die Benutzeroberfläche
 
 Die Agent-NN-Benutzeroberfläche ist intuitiv und benutzerfreundlich gestaltet, mit klaren Navigationselementen und einem zentralen Chat-Interface.
 
-![Benutzeroberfläche](ui_overview.png)
+![Benutzeroberfläche](Benutzeroberfläche.svg)
 
 ### Hauptelemente
 
@@ -272,7 +272,7 @@ Die Interaktion mit Agent-NN erfolgt hauptsächlich über natürlichsprachliche 
 2. Klicken Sie auf "Neue Konversation" oder verwenden Sie die Tastenkombination Ctrl+N/Cmd+N
 3. Beginnen Sie mit einer Nachricht an das System
 
-![Chat-Interaktion](chat_interaction.png)
+![Chat-Interaktion](Chat-Interaktion.svg)
 
 ### Direkte Agentenwahl
 
@@ -290,7 +290,7 @@ Agent-NN kann komplexe Aufgaben ausführen:
 3. Der Supervisor-Agent analysiert Ihre Anfrage und delegiert sie an den passenden Spezialisten
 4. Bei Bedarf können Agenten Rückfragen stellen oder Klarstellungen erbitten
 
-![Aufgabendelegation](task_delegation.png)
+![Aufgabendelegation](Aufgabendelegation.svg)
 
 ### Multi-Agent-Zusammenarbeit
 
@@ -323,7 +323,7 @@ Der Finanz-Agent ist Ihr Experte für alle finanzbezogenen Fragen und Aufgaben.
 - "Entwickle eine Finanzprognose für mein Startup"
 - "Berechne wichtige Finanzkennzahlen für dieses Unternehmen"
 
-![Finanz-Agent](finance_agent.png)
+![Finanz-Agent](Finanz-Agent.svg)
 
 ### Tech-Agent
 
@@ -343,7 +343,7 @@ Der Tech-Agent ist Ihr Spezialist für technische Fragen und Softwareentwicklung
 - "Implementiere Sicherheits-Best-Practices in meinem System"
 - "Hilf mir bei der Fehlerbehebung dieses technischen Problems"
 
-![Tech-Agent](tech_agent.png)
+![Tech-Agent](Tech-Agent.svg)
 
 ### Marketing-Agent
 
@@ -363,7 +363,7 @@ Der Marketing-Agent ist Ihr Experte für Marketingstrategien und Kundenkommunika
 - "Analysiere Markttrends und Wettbewerb"
 - "Entwirf ein Kundenbindungsprogramm"
 
-![Marketing-Agent](marketing_agent.png)
+> TODO: Bild einfügen: ./marketing_agent.png
 
 ### Web-Agent
 
@@ -392,7 +392,7 @@ Agent-NN ermöglicht es Ihnen, eigene Dokumente und Wissensquellen zu verwalten,
 4. Ordnen Sie das Dokument einer oder mehreren Domänen zu
 5. Fügen Sie optionale Metadaten hinzu, um die Auffindbarkeit zu verbessern
 
-![Dokumentenupload](document_upload.png)
+![Dokumentenupload](Dokumentenupload.svg)
 
 ### Wissensbasen verwalten
 
@@ -410,7 +410,7 @@ Sie können Agenten anweisen, spezifische Webquellen zu überwachen und zu integ
 3. Legen Sie Aktualisierungsintervalle fest
 4. Die Informationen werden automatisch in die relevanten Wissensbasen aufgenommen
 
-![Web-Integration](web_integration.png)
+![Web-Integration](Web-Integration.svg)
 
 ## Erweiterte Funktionen
 
@@ -426,7 +426,7 @@ Sie können wiederkehrende Aufgaben automatisieren:
 4. Konfigurieren Sie die auszuführenden Aufgaben
 5. Legen Sie Benachrichtigungspräferenzen fest
 
-![Workflow-Erstellung](workflow_creation.png)
+![Workflow-Erstellung](Workflow-Erstellung.svg)
 
 ### Benutzerdefinierte Agenten
 
@@ -447,7 +447,7 @@ Agent-NN kann mit verschiedenen externen Systemen integriert werden:
 - **Webhook-Benachrichtigungen**: Für ereignisbasierte Automatisierung
 - **Drittanbieter-Apps**: Verbindung zu Slack, Teams, Trello und mehr
 
-![Integrationsoptionen](integration_options.png)
+![Integrationsoptionen](Integrationsoptionen.svg)
 
 ### Erweiterte Analysen
 
@@ -482,7 +482,7 @@ Hier finden Sie Lösungen für häufig auftretende Probleme.
 3. Geben Sie zusätzlichen Kontext, um die Absicht zu verdeutlichen
 4. Geben Sie Feedback, damit das System lernen kann
 
-![Fehlerbehebung Agenten-Auswahl](agent_selection_troubleshooting.png)
+![Fehlerbehebung Agenten-Auswahl](FehlerbehebungAgenten-Auswahl.svg)
 
 ### Langsame Antworten
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,4 +2,4 @@
 
 Dieses Release finalisiert die Flowise-Export-Funktion und erweitert die Dokumentation.
 Fehlercodes sind vereinheitlicht und die Monitoring-Konfiguration wurde verbessert.
-Details siehe [CHANGELOG](../CHANGELOG.md).
+Details siehe [CHANGELOG](https://github.com/EcoSphereNetwork/Agent-NN/blob/main/CHANGELOG.md).

--- a/docs/api/chat.md
+++ b/docs/api/chat.md
@@ -23,7 +23,7 @@ Response:
 }
 ```
 
-## GET /chat/history/{session_id}
+## GET `/chat/history/{session_id}`
 Return the stored interaction history for a session.
 
 ## POST /chat/feedback

--- a/docs/cli/CLI-Dokumentation.md
+++ b/docs/cli/CLI-Dokumentation.md
@@ -26,7 +26,7 @@ Die CLI ist ideal für:
 - Leistungsüberwachung und -optimierung
 - Modell- und Systemkonfiguration
 
-![CLI-Übersicht](cli-overview-svg)
+![CLI-Übersicht](CLI-Übersicht.svg)
 
 ## Installation
 
@@ -123,7 +123,7 @@ Optionen:
 - `--output-format`: Format der Ausgabedateien (json, csv, yaml)
 - `--output-dir`: Verzeichnis für Ausgabedateien
 
-![CLI Batch-Verarbeitung](cli-batch-processing-svg)
+![CLI Batch-Verarbeitung](CLI-Batch-Verarbeitung.svg)
 
 ### Batch-Status überwachen
 
@@ -147,7 +147,7 @@ Starten Sie eine Echtzeit-Überwachung des Systems:
 agent-nn monitor --live
 ```
 
-![CLI Performance-Überwachung](cli-performance-monitoring-svg)
+![CLI Performance-Überwachung](CLI-Performance-Überwachung.svg)
 
 ### Leistungsbericht generieren
 
@@ -335,7 +335,7 @@ Der typische Workflow mit der CLI umfasst:
 2. **Modell auswählen**: Wählen Sie ein Modell für Ihre Aufgaben
 3. **Aufgabe ausführen**: Führen Sie eine Aufgabe aus oder starten Sie den Chat-Modus
 
-![CLI Workflow-Diagramm](cli-workflow-diagram-svg)
+![CLI Workflow-Diagramm](CLI-Workflow-Diagramm.svg)
 
 ## Grundlegende Befehle
 
@@ -409,7 +409,7 @@ Beispiel:
 agent-nn task "Erstelle eine Finanzanalyse für mein Portfolio basierend auf den aktuellen Markttrends" --domain finance --output json --save portfolio_analysis.json
 ```
 
-![CLI Aufgabenausführung](cli-task-execution-svg)
+![CLI Aufgabenausführung](CLI-Aufgabenausführung.svg)
 
 ### Ausgabeformate
 
@@ -445,7 +445,7 @@ Beispiel:
 agent-nn chat --model gpt-4 --system-prompt "Du bist ein Finanzberater mit Fachwissen in Kryptowährungen"
 ```
 
-![CLI Interaktiver Chat](cli-interactive-chat-svg)
+![CLI Interaktiver Chat](CLI-Interaktiver-Chat.svg)
 
 ### Chat-Befehle
 
@@ -481,6 +481,6 @@ Optionen:
 - `--backend`: Filtert nach Backend-Typ (openai, llamafile, lmstudio)
 - `--details`: Zeigt detaillierte Modellinformationen an
 
-![CLI Modellverwaltung](cli-model-management-svg)
+![CLI Modellverwaltung](CLI-Modellverwaltung.svg)
 
 ###

--- a/docs/flowisehub_publish.md
+++ b/docs/flowisehub_publish.md
@@ -22,7 +22,7 @@ The archive contains the compiled JavaScript files, node definitions and `flowis
 ## Repository and Release
 
 Tag a GitHub release to provide a stable download link. The repository URL is
-<https://github.com/EcoSphereNetwork/Agent-NN>. GitHub Pages can host a preview page under `dist/index.html` with screenshots and usage instructions.
+https://github.com/EcoSphereNetwork/Agent-NN. GitHub Pages can host a preview page under `dist/index.html` with screenshots and usage instructions.
 
 ## Submitting to FlowiseHub
 

--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -5,5 +5,5 @@ end users. Messages are sent to the API gateway via `POST /chat` and the
 history is kept per session. The current agent can be selected from a drop
 -down list.
 
-![Chat UI](chat_screenshot.png)
+![Chat UI](../BenutzerHandbuch/Chat-Interaktion.svg)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,12 +46,8 @@ Agent-NN is a sophisticated multi-agent system that combines large language mode
 - System-wide monitoring
 
 ## Getting Started
+For a practical introduction, see the [User Guide](BenutzerHandbuch/index.md).
 
-To get started with Agent-NN, check out the following sections:
-
-1. [Installation Guide](getting-started/installation.md)
-2. [Quick Start Tutorial](getting-started/quickstart.md)
-3. [Configuration Guide](getting-started/configuration.md)
 
 ## Architecture Overview
 
@@ -68,7 +64,7 @@ graph TD
     B --> H[Evaluation]
 ```
 
-For more details about the system architecture, see the [Architecture Guide](concepts/architecture.md).
+For more details about the system architecture, see the [Architecture Overview](architecture/overview.md).
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "agent-nn",
+  "name": "agent-nn-docs",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agent-nn",
+      "name": "agent-nn-docs",
       "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
         "@docusaurus/core": "^3.8.1",
         "@docusaurus/preset-classic": "^3.8.1"


### PR DESCRIPTION
## Summary
- fix case of image references in German user manual and add placeholder for missing Marketing screenshot
- use absolute link to CHANGELOG in release notes
- tweak API and CLI docs for correct image names and anchors
- update frontend overview and main docs entry
- adjust package-lock.json name

## Testing
- `npm ci`
- `npm run build` *(fails: WARNING for flowise_example.png but build succeeded)*
- `GIT_USER=EcoSphereNetwork USE_SSH=true npm run deploy` *(failed: Error while executing command `git remote get-url origin`)*

------
https://chatgpt.com/codex/tasks/task_e_686d805140d88324a8f99380d4291408