### PR TITLE
Document gh-pages deployment attempt

### DIFF
--- a/codex_progress.log
+++ b/codex_progress.log
@@ -1,0 +1,3 @@
+Added origin remote for GitHub repository.
+Created gh-pages branch with README placeholder.
+Attempted Docusaurus deploy, but deployment failed due to network restrictions (SSH port unreachable).


### PR DESCRIPTION
## Summary
- log attempts to deploy documentation to GitHub Pages

## Testing
- `npm install`
- `GIT_USER=EcoSphereNetwork USE_SSH=true npm run deploy` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d888bfe008324bdafbf2f85d773ae