### PR TITLE
Fix docs deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Agent-NN ist ein Multi-Agent-System mit integrierten neuronalen Netzen. Jeder Service erfüllt eine klar definierte Aufgabe und kommuniziert über REST-Schnittstellen. Neben den Backend-Diensten stellt das Projekt ein Python‑SDK, eine CLI und ein React-basiertes Frontend bereit.
 
-📄 [Zur Dokumentation](https://ecospheretwork.github.io/Agent-NN/)
+📄 [Online-Dokumentation](https://ecospheretwork.github.io/Agent-NN/)
 **Aktuelle Version:** v1.0.3 – Robuste Setup-Skripte und verbesserte Docker-Kompatibilität
 
 ## 🚀 Quick Start

--- a/deploy_docs.sh
+++ b/deploy_docs.sh
@@ -19,6 +19,6 @@ fi
 touch build/.nojekyll
 
 # Deploy using docusaurus deploy
-npm run deploy-docs
+npm run deploy
 
 echo "Deployment abgeschlossen."

--- a/docs/flowise_nodes.md
+++ b/docs/flowise_nodes.md
@@ -48,7 +48,7 @@ const result = await node.run();
 
 Die generierten `.node.json` Dateien enthalten jetzt zusätzliche Felder für Farbe, Icon und Kategorie. Damit erscheinen die Agent-NN Nodes in Flowise einheitlich unter der Kategorie **Agent-NN**.
 
-![Node Preview](integrations/flowise_example.png)
+> TODO: Screenshot "flowise_example.png" ergänzen
 
 Zur Installation in einer lokalen Flowise Instanz kann das Skript `flowise_deploy.py` verwendet werden:
 

--- a/docs/flowise_plugin.md
+++ b/docs/flowise_plugin.md
@@ -35,4 +35,4 @@ Vorhandene Installationen werden nur überschrieben, wenn die neue Version höhe
 1. Lade das Archiv im Flowise‑Plugin-Manager hoch oder kopiere es in das Plugin-Verzeichnis.
 2. Starte Flowise neu. Die Agent‑NN Nodes erscheinen anschließend unter der Kategorie **Agent-NN**.
 
-![Plugin Example](integrations/flowise_example.png)
+> TODO: Screenshot "flowise_example.png" ergänzen

--- a/docs/integrations/flowise.md
+++ b/docs/integrations/flowise.md
@@ -63,7 +63,7 @@ Diese Komponente wird in Flowise eingebunden und erlaubt es, Benutzeranfragen di
 3. Optional können `taskType`, `path`, `method`, `headers`, `auth` und
    `timeout` angepasst werden.
 
-![Flowise Example](flowise_example.png)
+> TODO: Screenshot "flowise_example.png" ergänzen
 
 Nach dem Upload kann die Komponente sofort verwendet werden. Konfiguriere die
 Basis-URL von Agent‑NN sowie optionale Header oder ein anderes Timeout.

--- a/docs/integrations/flowise_example.png
+++ b/docs/integrations/flowise_example.png
@@ -1,1 +1,0 @@
-docs/integrations/flowise_example.png

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "scripts": {
     "build": "../node_modules/.bin/docusaurus build ..",
-    "deploy-docs": "../node_modules/.bin/docusaurus deploy .."
+    "deploy-docs": "docusaurus deploy"
   }
 }


### PR DESCRIPTION
## Summary
- remove invalid Flowise screenshot reference
- add `deploy-docs` npm script to docs
- invoke docusaurus deploy in helper script
- update README link for online docs

## Testing
- `npm run build`
- `./deploy_docs.sh` *(fails: no remote 'origin')*

------
https://chatgpt.com/codex/tasks/task_e_686da4234668832486603f323f599957