### PR TITLE
Fix docs deploy path

### DIFF
--- a/codex_progress.log
+++ b/codex_progress.log
@@ -9,3 +9,4 @@ Local Docusaurus build succeeded; 404.html generated automatically.
 Docs not yet reachable on GitHub Pages (curl 404).
 CI tests fail due to existing ruff lint errors.
 Tue Jul  8 22:12:22 UTC 2025: Begin fix docs deployment
+Tue Jul  8 23:20:40 UTC 2025: Adjusted deploy-docs script to use parent config

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "scripts": {
     "build": "../node_modules/.bin/docusaurus build ..",
-    "deploy-docs": "docusaurus deploy"
+    "deploy-docs": "../node_modules/.bin/docusaurus deploy .."
   }
 }


### PR DESCRIPTION
## Summary
- adjust docs npm script to deploy from parent directory
- update progress log

## Testing
- `ruff check .` *(fails: E402 in services/core.py)*
- `mypy mcp`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686da762003c832493c5fd45c30e654e