### PR TITLE
Fix unused TS parameter

### DIFF
--- a/frontend/agent-ui/src/hooks/useApi.ts
+++ b/frontend/agent-ui/src/hooks/useApi.ts
@@ -317,7 +317,7 @@ export const useCurrentUser = () => {
     onSuccess: (user) => {
       useAppStore.getState().setUser(user)
     },
-    onError: (error) => {
+    onError: (_error: unknown) => {
       useAppStore.getState().setAuthenticated(false)
     }
   })


### PR DESCRIPTION
## Summary
- annotate error parameter in `useCurrentUser` to avoid unused variable warning

## Testing
- `ruff check .` *(fails: Found 7 errors)*
- `mypy mcp`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_686e0f0ef1e883248a0b3fa65671d588