### PR TITLE
Fix bash libs and unify docker helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,9 @@ Zur Fehlersuche helfen `docker ps`, `npm run build` im Frontend-Verzeichnis sowi
 | `scripts/deploy_to_registry.sh` | Publiziert Images in ein Container-Registry |
 | `scripts/start_mcp.sh` | Startet das Microservice-Compose-Setup |
 | `scripts/setup.sh` | Komplettes Setup in einem Schritt |
+| `scripts/lib/` | Wiederverwendbare Bash-Module für Docker- und Environment-Checks |
+
+Die Library-Skripte erwarten eine konfigurierte `.env` und prüfen die Ports `8000`, `3000`, `5432`, `6379` und `9090`.
 
 ## Poetry-Workflow
 

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -2,29 +2,30 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers/common.sh"
 LOG_DIR="$SCRIPT_DIR/../logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/deploy_docs.log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-echo "[docs] Prüfe Abhängigkeiten"
+log_info "Prüfe Abhängigkeiten"
 if [[ ! -d node_modules ]]; then
   npm ci
 fi
 
-echo "[docs] Baue Docusaurus"
+log_info "Baue Docusaurus"
 npm run build
 
 if [[ ! -d build ]]; then
-  echo "[docs] Build fehlgeschlagen" >&2
+  log_err "Build fehlgeschlagen"
   exit 1
 fi
 
-echo "[docs] Deploye nach gh-pages"
+log_info "Deploye nach gh-pages"
 git worktree add -B gh-pages ../gh-pages origin/gh-pages
 cp -r build/* ../gh-pages/
 git -C ../gh-pages add .
 git -C ../gh-pages commit -am "📚 deploy: $(date +%F_%T)"
 git -C ../gh-pages push origin gh-pages
 
-echo "[docs] Deployment abgeschlossen"
+log_ok "Deployment abgeschlossen"

--- a/scripts/lib/env_check.sh
+++ b/scripts/lib/env_check.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../helpers/common.sh"
+__env_check_init() {
+    local SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$SCRIPT_DIR/../helpers/common.sh"
+}
 
-check_env_file() {
+__env_check_init
+
+check_dotenv_file() {
     local env_file="${1:-.env}"
     local example_file="${2:-.env.example}"
 
@@ -15,6 +19,8 @@ check_env_file() {
             log_err "$env_file und Vorlage $example_file fehlen"
             return 1
         fi
+    else
+        log_ok "$env_file vorhanden"
     fi
     return 0
 }
@@ -31,11 +37,16 @@ check_ports() {
         log_warn "Ports belegt: ${blocked[*]}"
         return 1
     fi
+    log_ok "Alle Ports frei"
     return 0
 }
 
-env_check() {
-    check_env_file && check_ports 8000 3000 5432 6379 9090
+log_env_status() {
+    log_info "Aktuelle .env Einstellungen:" && grep -v '^#' .env 2>/dev/null || true
 }
 
-export -f check_env_file check_ports env_check
+env_check() {
+    check_dotenv_file && check_ports 8000 3000 5432 6379 9090
+}
+
+export -f check_dotenv_file check_ports log_env_status env_check

--- a/scripts/lib/frontend_build.sh
+++ b/scripts/lib/frontend_build.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../helpers/common.sh"
+__frontend_build_init() {
+    local SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$SCRIPT_DIR/../helpers/common.sh"
+}
+
+__frontend_build_init
 
 build_frontend() {
+    local SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     local dir="$SCRIPT_DIR/../../frontend/agent-ui"
     local target="$SCRIPT_DIR/../../frontend/dist"
 
@@ -26,6 +31,7 @@ build_frontend() {
     cp -r "$dir"/dist/* "$target"/ 2>/dev/null || true
     log_info "Build-Output:"
     ls -al "$target" || true
+    log_ok "Frontend-Build abgeschlossen"
 }
 
 export -f build_frontend

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,29 +5,21 @@
 set -euo pipefail
 
 # Skript-Verzeichnis und Helpers laden
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-readonly HELPERS_DIR="$SCRIPT_DIR/helpers"
-readonly LIB_DIR="$SCRIPT_DIR/lib"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
-# Alle Helper-Module laden
-for helper in "$HELPERS_DIR"/{common,env,docker,frontend}.sh; do
-    if [[ -f "$helper" ]]; then
-        source "$helper"
-    else
-        echo "FEHLER: Helper-Datei nicht gefunden: $helper" >&2
-        exit 1
-    fi
-done
+source "$SCRIPT_DIR/helpers/common.sh"
+source "$SCRIPT_DIR/helpers/env.sh"
+source "$SCRIPT_DIR/helpers/docker.sh"
+source "$SCRIPT_DIR/helpers/frontend.sh"
 
-# Zusätzliche Library-Module laden
-for lib in "$LIB_DIR"/*.sh; do
-    [[ -f "$lib" ]] && source "$lib"
-done
+source "$SCRIPT_DIR/lib/env_check.sh"
+source "$SCRIPT_DIR/lib/docker_utils.sh"
+source "$SCRIPT_DIR/lib/frontend_build.sh"
 
 # Globale Variablen
-readonly SCRIPT_NAME="$(basename "$0")"
-readonly LOG_FILE="$REPO_ROOT/logs/setup.log"
+SCRIPT_NAME="$(basename "$0")"
+LOG_FILE="$REPO_ROOT/logs/setup.log"
 BUILD_FRONTEND=true
 START_DOCKER=true
 VERBOSE=false

--- a/scripts/start_docker.sh
+++ b/scripts/start_docker.sh
@@ -29,14 +29,12 @@ done
 
 compose_file="docker-compose${ENV_NAME:+.$ENV_NAME}.yml"
 
-if ! has_docker || ! has_docker_compose; then
-    log_err "Docker oder Docker Compose fehlt"
-    exit 1
-fi
+check_docker || exit 1
+check_docker_compose || exit 1
 
 if [[ ! -f "$compose_file" ]]; then
     log_warn "Compose-Datei $compose_file nicht gefunden"
     exit 0
 fi
 
-start_compose "$compose_file"
+start_docker_services "$compose_file"


### PR DESCRIPTION
## Summary
- refactor bash lib modules to avoid readonly `SCRIPT_DIR`
- modularize `docker_utils` with new logging helpers
- enhance environment checks and frontend build script
- simplify setup and other entrypoints to source libs directly
- document lib scripts and port checks in README

## Testing
- `ruff check .` *(fails: E402 in services/core.py)*
- `mypy mcp`
- `pytest -m "not heavy" -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5019ecd0832497bf68d0f79a6916