### PR TITLE
Refactor setup helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Vielen Dank für dein Interesse an Agent-NN! Dieses Projekt verwendet GitHub Flo
 
 1. Forke das Repository und klone deine Kopie.
 2. Installiere Abhängigkeiten mit `pip install -r requirements.txt`.
+   Alternativ kannst du `./scripts/install.sh --ci` nutzen, um alle
+   benötigten Tools automatisiert zu installieren.
 3. Richte optionale Hooks ein:
    ```bash
    pip install pre-commit

--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ Das Setup-System erkennt automatisch:
 ./scripts/test.sh
 ```
 
+### Weitere CLI-Tools
+
+- `./scripts/install.sh` – einzelne Abhängigkeiten installieren, z. B. `./scripts/install.sh --node`
+- `./scripts/help.sh` – kurze Übersicht aller Skripte und wichtiger Flags
+- `./scripts/build_frontend.sh` – nur das Frontend bauen
+- `./scripts/build_and_test.sh` – Container bauen und Tests ausführen
+
+Beispiel für Teilinstallationen:
+
+```bash
+./scripts/install.sh --docker --node
+```
+
 ### Manuelles Setup
 ```bash
 # 1. Repository klonen
@@ -342,6 +355,9 @@ poetry run ruff check .
 poetry run mypy mcp
 ```
 
+Eigene Skripte können die Helfer aus `scripts/lib/` einbinden, um Logging,
+Spinner und Installationsroutinen wiederzuverwenden.
+
 ### Code-Style
 - **Python:** Ruff + MyPy
 - **JavaScript/TypeScript:** ESLint + Prettier
@@ -475,7 +491,7 @@ Zur Fehlersuche helfen `docker ps`, `npm run build` im Frontend-Verzeichnis sowi
 | `scripts/deploy_to_registry.sh` | Publiziert Images in ein Container-Registry |
 | `scripts/start_mcp.sh` | Startet das Microservice-Compose-Setup |
 | `scripts/setup.sh` | Komplettes Setup in einem Schritt |
-| `scripts/lib/` | Wiederverwendbare Bash-Module für Docker- und Environment-Checks |
+| `scripts/lib/` | Wiederverwendbare Bash-Module (log_utils, spinner_utils, install_utils ...) |
 
 Die Library-Skripte erwarten eine konfigurierte `.env` und prüfen die Ports `8000`, `3000`, `5432`, `6379` und `9090`.
 

--- a/scripts/build_and_start.sh
+++ b/scripts/build_and_start.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/log_utils.sh"
 source "$SCRIPT_DIR/lib/env_check.sh"
 source "$SCRIPT_DIR/lib/docker_utils.sh"
 cd "$SCRIPT_DIR/.."

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/log_utils.sh"
 source "$SCRIPT_DIR/lib/env_check.sh"
 source "$SCRIPT_DIR/lib/docker_utils.sh"
 

--- a/scripts/build_frontend.sh
+++ b/scripts/build_frontend.sh
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/log_utils.sh"
 source "$SCRIPT_DIR/lib/env_check.sh"
 source "$SCRIPT_DIR/lib/docker_utils.sh"
 source "$SCRIPT_DIR/helpers/frontend.sh"

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/log_utils.sh"
+
+cat <<'EOT'
+Agent-NN Befehlsübersicht
+
+  ./scripts/setup.sh         Vollständiges oder teilweises Setup
+  ./scripts/install.sh       Abhängigkeiten gezielt installieren
+  ./scripts/start_docker.sh  Docker-Services starten
+  ./scripts/build_frontend.sh Frontend bauen
+  ./scripts/build_and_test.sh Docker-Image bauen und Tests ausführen
+
+Wichtige Flags für setup.sh:
+  --full        Komplettes Setup ohne Rückfragen
+  --minimal     Nur Python-Abhängigkeiten installieren
+  --no-docker   Docker-Schritte überspringen
+  --with-docker Setup bricht ab, wenn Docker fehlt
+
+Empfohlene Reihenfolge:
+  1. ./scripts/setup.sh --full
+  2. ./scripts/start_docker.sh
+  3. ./scripts/test.sh
+EOT

--- a/scripts/helpers/common.sh
+++ b/scripts/helpers/common.sh
@@ -7,39 +7,8 @@ if [[ "${_COMMON_SH_LOADED:-}" == "true" ]]; then
 fi
 readonly _COMMON_SH_LOADED=true
 
-# Farb-Codes für konsistente Ausgabe (only set if not already defined)
-if [[ -z "${RED:-}" ]]; then
-    readonly RED='\033[1;31m'
-    readonly GREEN='\033[1;32m'
-    readonly YELLOW='\033[1;33m'
-    readonly BLUE='\033[1;34m'
-    readonly PURPLE='\033[1;35m'
-    readonly CYAN='\033[1;36m'
-    readonly NC='\033[0m' # No Color
-fi
-
-# Logging-Funktionen mit UTF-8 Unterstützung
-log_info() { 
-    echo -e "${BLUE}[...]${NC} $1" 
-}
-
-log_ok() { 
-    echo -e "${GREEN}[✓]${NC} $1" 
-}
-
-log_warn() { 
-    echo -e "${YELLOW}[⚠]${NC} $1" 
-}
-
-log_err() { 
-    echo -e "${RED}[✗]${NC} $1" >&2 
-}
-
-log_debug() {
-    if [[ "${DEBUG:-}" == "1" ]]; then
-        echo -e "${PURPLE}[DEBUG]${NC} $1" >&2
-    fi
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/log_utils.sh"
 
 # Utility-Funktionen
 check_command() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/log_utils.sh"
+source "$SCRIPT_DIR/lib/spinner_utils.sh"
+source "$SCRIPT_DIR/lib/install_utils.sh"
+
+usage() {
+    cat <<EOT
+Usage: $(basename "$0") [OPTIONS]
+Installiere gezielt Projekt-Abhängigkeiten.
+
+Optionen:
+  --docker       Docker und Compose installieren
+  --node         Node.js installieren
+  --python       Python installieren
+  --poetry       Poetry installieren
+  --ci           Installiert Python, Poetry, Node und Docker
+  -h, --help     Diese Hilfe anzeigen
+EOT
+}
+
+components=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --docker) components+=(ensure_docker); shift;;
+        --node) components+=(ensure_node); shift;;
+        --python) components+=(ensure_python); shift;;
+        --poetry) components+=(ensure_poetry); shift;;
+        --ci)
+            components=(ensure_python ensure_poetry ensure_node ensure_docker)
+            shift;;
+        -h|--help)
+            usage; exit 0;;
+        *)
+            log_err "Unbekannte Option: $1"
+            usage; exit 1;;
+    esac
+done
+
+if [[ ${#components[@]} -eq 0 ]]; then
+    usage
+    exit 1
+fi
+
+for comp in "${components[@]}"; do
+    with_spinner "Installiere ${comp#ensure_}" "$comp" || true
+done
+
+exit 0

--- a/scripts/lib/args_parser.sh
+++ b/scripts/lib/args_parser.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+__args_parser_init() {
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$SCRIPT_DIR/log_utils.sh"
+}
+__args_parser_init
+
+parse_setup_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -v|--verbose)
+                VERBOSE=true
+                export DEBUG=1
+                ;;
+            --no-frontend)
+                BUILD_FRONTEND=false
+                ;;
+            --skip-docker)
+                START_DOCKER=false
+                ;;
+            --check-only)
+                BUILD_FRONTEND=false
+                START_DOCKER=false
+                ;;
+            --install-heavy)
+                INSTALL_HEAVY=true
+                ;;
+            --with-docker)
+                WITH_DOCKER=true
+                ;;
+            --full)
+                AUTO_MODE=true
+                RUN_MODE="full"
+                ;;
+            --minimal)
+                START_DOCKER=false
+                BUILD_FRONTEND=false
+                AUTO_MODE=true
+                RUN_MODE="python"
+                ;;
+            --no-docker)
+                START_DOCKER=false
+                ;;
+            --clean)
+                clean_environment
+                exit 0
+                ;;
+            *)
+                log_err "Unbekannte Option: $1"
+                usage >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+}
+
+export -f parse_setup_args

--- a/scripts/lib/docker_utils.sh
+++ b/scripts/lib/docker_utils.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 __docker_utils_init() {
-    local SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$SCRIPT_DIR/log_utils.sh"
     source "$SCRIPT_DIR/../helpers/common.sh"
 }
 

--- a/scripts/lib/env_check.sh
+++ b/scripts/lib/env_check.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 __env_check_init() {
-    local SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$SCRIPT_DIR/log_utils.sh"
     source "$SCRIPT_DIR/../helpers/common.sh"
 }
 

--- a/scripts/lib/frontend_build.sh
+++ b/scripts/lib/frontend_build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 __frontend_build_init() {
-    local SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$SCRIPT_DIR/log_utils.sh"
     source "$SCRIPT_DIR/../helpers/common.sh"
 }
 

--- a/scripts/lib/install_utils.sh
+++ b/scripts/lib/install_utils.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 __install_utils_init() {
-    local SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$SCRIPT_DIR/log_utils.sh"
     source "$SCRIPT_DIR/../helpers/common.sh"
+    source "$SCRIPT_DIR/spinner_utils.sh"
 }
 
 __install_utils_init
@@ -115,27 +117,3 @@ ensure_python_tools() {
 
 export -f ask_install install_docker ensure_docker install_node ensure_node install_python ensure_python install_poetry ensure_poetry install_python_tool ensure_python_tools
 
-show_spinner() {
-    local pid=$1
-    local delay=0.1
-    local spin='|/-\\'
-    while kill -0 "$pid" 2>/dev/null; do
-        for i in $spin; do
-            printf "\r[%s] $SPINNER_MSG" "$i"
-            sleep $delay
-        done
-    done
-    wait "$pid" 2>/dev/null
-    printf "\r"
-}
-
-with_spinner() {
-    SPINNER_MSG="$1"; shift
-    ("$@") &
-    local pid=$!
-    show_spinner $pid
-    local status=$?
-    return $status
-}
-
-export -f show_spinner with_spinner

--- a/scripts/lib/log_utils.sh
+++ b/scripts/lib/log_utils.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Logging utilities for scripts
+
+# initialization
+__log_utils_init() {
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+}
+__log_utils_init
+
+# color codes (if not already defined)
+if [[ -z "${RED:-}" ]]; then
+    readonly RED='\033[1;31m'
+    readonly GREEN='\033[1;32m'
+    readonly YELLOW='\033[1;33m'
+    readonly BLUE='\033[1;34m'
+    readonly PURPLE='\033[1;35m'
+    readonly CYAN='\033[1;36m'
+    readonly NC='\033[0m'
+fi
+
+log_info() {
+    echo -e "${BLUE}[...]${NC} $1"
+}
+
+log_ok() {
+    echo -e "${GREEN}[✓]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[⚠]${NC} $1"
+}
+
+log_err() {
+    echo -e "${RED}[✗]${NC} $1" >&2
+}
+
+log_debug() {
+    if [[ "${DEBUG:-}" == "1" ]]; then
+        echo -e "${PURPLE}[DEBUG]${NC} $1" >&2
+    fi
+}
+
+export -f log_info log_ok log_warn log_err log_debug

--- a/scripts/lib/menu_utils.sh
+++ b/scripts/lib/menu_utils.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+__menu_utils_init() {
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$SCRIPT_DIR/log_utils.sh"
+}
+__menu_utils_init
+
+interactive_menu() {
+    PS3="Auswahl: "
+    options=(
+        "Komplettes Setup (Empfohlen)"
+        "Nur Python-Abhängigkeiten installieren"
+        "Nur Frontend bauen"
+        "Docker-Container starten"
+        "Projekt testen"
+        "Abbrechen"
+    )
+    select opt in "${options[@]}"; do
+        case $REPLY in
+            1) RUN_MODE="full"; break ;;
+            2) RUN_MODE="python"; break ;;
+            3) RUN_MODE="frontend"; break ;;
+            4) RUN_MODE="docker"; break ;;
+            5) RUN_MODE="test"; break ;;
+            6) exit 0 ;;
+            *) echo "Ungültige Auswahl";;
+        esac
+    done
+}
+
+export -f interactive_menu

--- a/scripts/lib/spinner_utils.sh
+++ b/scripts/lib/spinner_utils.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+__spinner_utils_init() {
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$SCRIPT_DIR/log_utils.sh"
+}
+__spinner_utils_init
+
+show_spinner() {
+    local pid=$1
+    local delay=0.1
+    local spin='|/-\\'
+    while kill -0 "$pid" 2>/dev/null; do
+        for i in $spin; do
+            printf "\r[%s] $SPINNER_MSG" "$i"
+            sleep $delay
+        done
+    done
+    wait "$pid" 2>/dev/null
+    printf "\r"
+}
+
+with_spinner() {
+    SPINNER_MSG="$1"; shift
+    ("$@") &
+    local pid=$!
+    show_spinner $pid
+    local status=$?
+    return $status
+}
+
+export -f show_spinner with_spinner

--- a/scripts/start_docker.sh
+++ b/scripts/start_docker.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/log_utils.sh"
 source "$SCRIPT_DIR/helpers/common.sh"
 source "$SCRIPT_DIR/lib/env_check.sh"
 source "$SCRIPT_DIR/lib/docker_utils.sh"

--- a/scripts/start_mcp.sh
+++ b/scripts/start_mcp.sh
@@ -2,6 +2,7 @@
 # Start MCP services for local development
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/log_utils.sh"
 source "$SCRIPT_DIR/lib/env_check.sh"
 source "$SCRIPT_DIR/lib/docker_utils.sh"
 cd "$SCRIPT_DIR/.."


### PR DESCRIPTION
## Summary
- modularize Bash utilities under `scripts/lib`
- add `install.sh` and `help.sh`
- update existing scripts to source the new modules
- document new CLI tools and library usage in README and CONTRIBUTING

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e65a16cc08324afed047aef989ed6