### PR TITLE
Fix setup script paths and status handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Wiederkehrende Einstellungen lassen sich über `--preset` laden:
 ./scripts/setup.sh --preset ci        # Nur Python + Tests
 ./scripts/setup.sh --preset minimal   # Ohne Docker/Node
 ```
+Verf\u00fcgbare Presets: `dev`, `ci`, `minimal`. Damit lassen sich typische
+Installationsszenarien ohne viele Eingaben starten.
 
 ```bash
 # Basis-Setup
@@ -178,8 +180,8 @@ pip install docker-compose
 ./scripts/setup.sh --check-only
 # Erweiterte Validierung vor einem Pull Request
 ./scripts/validate.sh
-# Aktuellen Setup-Status anzeigen
-./scripts/status.sh
+# Aktuellen Setup-Status pr\u00fcfen
+./scripts/status.sh  # zeigt letztes Setup, verwendetes Preset und Konsistenz
 
 # Alternative: Ports in docker-compose.yml ändern
 nano docker-compose.yml

--- a/scripts/helpers/common.sh
+++ b/scripts/helpers/common.sh
@@ -7,8 +7,8 @@ if [[ "${_COMMON_SH_LOADED:-}" == "true" ]]; then
 fi
 readonly _COMMON_SH_LOADED=true
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../lib/log_utils.sh"
+_COMMON_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_COMMON_HELPER_DIR/../lib/log_utils.sh"
 
 # Utility-Funktionen
 check_command() {

--- a/scripts/lib/args_parser.sh
+++ b/scripts/lib/args_parser.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 __args_parser_init() {
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    source "$SCRIPT_DIR/log_utils.sh"
+    local dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$dir/log_utils.sh"
 }
 __args_parser_init
 

--- a/scripts/lib/config_utils.sh
+++ b/scripts/lib/config_utils.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 __config_utils_init() {
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    source "$SCRIPT_DIR/log_utils.sh"
+    local dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$dir/log_utils.sh"
 }
 __config_utils_init
 

--- a/scripts/lib/docker_utils.sh
+++ b/scripts/lib/docker_utils.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 __docker_utils_init() {
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    source "$SCRIPT_DIR/log_utils.sh"
-    source "$SCRIPT_DIR/../helpers/common.sh"
-    source "$SCRIPT_DIR/status_utils.sh"
+    local dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    DOCKER_UTILS_DIR="$dir"
+    source "$dir/log_utils.sh"
+    source "$dir/../helpers/common.sh"
+    source "$dir/status_utils.sh"
 }
 
 __docker_utils_init
@@ -58,7 +59,7 @@ start_docker_services() {
     log_info "Starte Docker-Services..."
     if docker_compose -f "$compose" up -d; then
         log_ok "Docker-Services gestartet"
-        update_status "docker" "ok" "$SCRIPT_DIR/../../.agentnn/status.json"
+        update_status "docker" "ok" "$DOCKER_UTILS_DIR/../../.agentnn/status.json"
     else
         log_err "Docker-Services konnten nicht gestartet werden"
         return 1

--- a/scripts/lib/env_check.sh
+++ b/scripts/lib/env_check.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 __env_check_init() {
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    source "$SCRIPT_DIR/log_utils.sh"
-    source "$SCRIPT_DIR/../helpers/common.sh"
+    local dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$dir/log_utils.sh"
+    source "$dir/../helpers/common.sh"
 }
 
 __env_check_init

--- a/scripts/lib/frontend_build.sh
+++ b/scripts/lib/frontend_build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 __frontend_build_init() {
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    source "$SCRIPT_DIR/log_utils.sh"
-    source "$SCRIPT_DIR/../helpers/common.sh"
-    source "$SCRIPT_DIR/status_utils.sh"
+    local dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$dir/log_utils.sh"
+    source "$dir/../helpers/common.sh"
+    source "$dir/status_utils.sh"
 }
 
 __frontend_build_init

--- a/scripts/lib/install_utils.sh
+++ b/scripts/lib/install_utils.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 __install_utils_init() {
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    source "$SCRIPT_DIR/log_utils.sh"
-    source "$SCRIPT_DIR/../helpers/common.sh"
-    source "$SCRIPT_DIR/spinner_utils.sh"
+    local dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$dir/log_utils.sh"
+    source "$dir/../helpers/common.sh"
+    source "$dir/spinner_utils.sh"
 }
 
 __install_utils_init

--- a/scripts/lib/log_utils.sh
+++ b/scripts/lib/log_utils.sh
@@ -4,7 +4,8 @@
 
 # initialization
 __log_utils_init() {
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    LOG_UTILS_DIR="$dir"
 }
 __log_utils_init
 

--- a/scripts/lib/menu_utils.sh
+++ b/scripts/lib/menu_utils.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 __menu_utils_init() {
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    source "$SCRIPT_DIR/log_utils.sh"
+    local dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$dir/log_utils.sh"
 }
 __menu_utils_init
 

--- a/scripts/lib/preset_utils.sh
+++ b/scripts/lib/preset_utils.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 
+# Preset definitions used by setup and install scripts.
+#
+# Available presets:
+#   dev     - full installation including Docker and frontend build
+#   ci      - dependencies for running the test-suite only
+#   minimal - Python environment without Docker or Node.js
+
 __preset_utils_init() {
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    source "$SCRIPT_DIR/log_utils.sh"
+    local dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$dir/log_utils.sh"
 }
 __preset_utils_init
 
 apply_preset() {
     local preset="$1"
+    PRESET="$preset"
     case "$preset" in
         dev)
             RUN_MODE="full"
@@ -25,7 +33,8 @@ apply_preset() {
             START_DOCKER=false
             ;;
         *)
-            log_warn "Unknown preset: $preset"
+            log_warn "Unbekanntes Preset: $preset"
+            PRESET=""
             return 1
             ;;
     esac

--- a/scripts/lib/spinner_utils.sh
+++ b/scripts/lib/spinner_utils.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 __spinner_utils_init() {
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    source "$SCRIPT_DIR/log_utils.sh"
+    local dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$dir/log_utils.sh"
 }
 __spinner_utils_init
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -316,6 +316,12 @@ main() {
     
     # Banner anzeigen
     print_banner
+
+    STATUS_FILE="$REPO_ROOT/.agentnn/status.json"
+    ensure_status_file "$STATUS_FILE"
+    if [[ -n "$PRESET" ]]; then
+        log_preset "$PRESET" "$STATUS_FILE"
+    fi
     
     # In Repository-Verzeichnis wechseln
     cd "$REPO_ROOT" || {


### PR DESCRIPTION
## Summary
- handle library paths using local variables
- document presets and status check in README
- add functions for status tracking and preset logging
- ensure setup.sh records chosen presets
- make status.sh output human readable

## Testing
- `pre-commit run --files README.md scripts/lib/preset_utils.sh scripts/lib/status_utils.sh scripts/setup.sh scripts/status.sh` *(fails: error: pathspec 'v8.2.0' did not match)*
- `./scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e77e1e098832491b3e32ffcb5c681